### PR TITLE
Add Prowlarr as an optional search backend alongside Jackett

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rapid bay is a self hosted video service/torrent client that makes playing video
 
 ## Features:
 
--   Uses [Jackett](https://github.com/Jackett/Jackett) as a search backend.
+-   Uses [Jackett](https://github.com/Jackett/Jackett) and/or [Prowlarr](https://github.com/Prowlarr/Prowlarr) as a search backend.
 -   Pick individual video files you want to play and the system takes care of the rest to make it streamable.
 -   Automatic download of Closed Captions/Subtitles
 -   Automatically converts the video file and subtitles to be playable on all browsers/chromecast/appletv
@@ -23,19 +23,28 @@ Rapid bay is a self hosted video service/torrent client that makes playing video
 
 ![](https://user-images.githubusercontent.com/2439255/48429861-44b60b00-e76e-11e8-8bdb-042f125357ce.gif)
 
-## Setting up Jackett as a search backend:
+## Setting up a search backend:
 
-Rapidbay requires the torrent indexer [Jackett](https://github.com/Jackett/Jackett) for searching.
-Have a look [here](https://github.com/Jackett/Jackett#installation-using-docker) on how to set it up using Docker.
+Rapidbay requires a torrent indexer for searching. You can use [Jackett](https://github.com/Jackett/Jackett), [Prowlarr](https://github.com/Prowlarr/Prowlarr), or both at the same time (results are merged and deduplicated).
 
-There's also a [docker-compose example](https://github.com/hauxir/rapidbay/blob/master/docker-compose.example.with.jackett.yml) file to show how you can connect rapidbay and jackett together.
+### Jackett
+
+Have a look [here](https://github.com/Jackett/Jackett#installation-using-docker) on how to set Jackett up using Docker. There's also a [docker-compose example](https://github.com/hauxir/rapidbay/blob/master/docker-compose.example.with.jackett.yml) showing how to connect rapidbay and Jackett together.
+
+### Prowlarr
+
+See the [Prowlarr docs](https://wiki.servarr.com/prowlarr/installation) for installation instructions. There's a [docker-compose example](https://github.com/hauxir/rapidbay/blob/master/docker-compose.example.with.prowlarr.yml) showing how to connect rapidbay and Prowlarr together.
 
 ## Running:
 
 ### With Docker (recommended)
 
 ```
-docker run -p 5000:5000 -e JACKETT_HOST="http://your.jacket.host" -e JACKETT_API_KEY="YourAPIKey" hauxir/rapidbay
+# Using Jackett
+docker run -p 5000:5000 -e JACKETT_HOST="http://your.jackett.host" -e JACKETT_API_KEY="YourAPIKey" hauxir/rapidbay
+
+# Using Prowlarr
+docker run -p 5000:5000 -e PROWLARR_HOST="http://your.prowlarr.host" -e PROWLARR_API_KEY="YourAPIKey" hauxir/rapidbay
 ```
 
 ### Without Docker
@@ -67,9 +76,11 @@ pip install .
 **Run the app:**
 
 ```bash
-# Set environment variables
-export JACKETT_HOST="http://your.jacket.host"
+# Set environment variables (Jackett, Prowlarr, or both)
+export JACKETT_HOST="http://your.jackett.host"
 export JACKETT_API_KEY="YourAPIKey"
+# export PROWLARR_HOST="http://your.prowlarr.host"
+# export PROWLARR_API_KEY="YourAPIKey"
 
 # Run directly (without nginx)
 cd app

--- a/app/app.py
+++ b/app/app.py
@@ -230,7 +230,10 @@ def _indexer_search(searchterm: str) -> List[Dict[str, Any]]:
     # Filter out results without magnet or torrent_link
     results = [r for r in results if r.get("magnet") or r.get("torrent_link")]
 
-    # Deduplicate by magnet hash (preferring the first occurrence, which has higher seeds after sort)
+    # Sort by seeds before dedup so the highest-seed entry wins for any duplicate
+    # hash/link encountered across backends.
+    results = sorted(results, key=lambda x: x.get("seeds", 0) or 0, reverse=True)
+
     seen_hashes: set[str] = set()
     seen_links: set[str] = set()
     deduped: List[Dict[str, Any]] = []
@@ -251,7 +254,7 @@ def _indexer_search(searchterm: str) -> List[Dict[str, Any]]:
             seen_links.add(link)
         deduped.append(r)
 
-    return sorted(deduped, key=lambda x: x.get("seeds", 0) or 0, reverse=True)
+    return deduped
 
 
 @app.get("/health")

--- a/app/app.py
+++ b/app/app.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any, AsyncIterator, Dict, List
 
 import http_cache
 import jackett
+import prowlarr
 import PTN
 import requests
 import settings
@@ -218,6 +219,41 @@ def _weighted_sort_date_seeds(results: List[Dict[str, Any]]) -> List[Dict[str, A
     return sorted(results, key=lambda x: (1+dates.index(getdate(x.get("published")))) * x.get("seeds", 0) * (x.get("seeds",0) * 1.5), reverse=True)
 
 
+def _indexer_search(searchterm: str) -> List[Dict[str, Any]]:
+    """Search configured indexer backends (Jackett and/or Prowlarr) and merge results."""
+    results: List[Dict[str, Any]] = []
+    if settings.JACKETT_HOST:
+        results.extend(jackett.search(searchterm))
+    if settings.PROWLARR_HOST:
+        results.extend(prowlarr.search(searchterm))
+
+    # Filter out results without magnet or torrent_link
+    results = [r for r in results if r.get("magnet") or r.get("torrent_link")]
+
+    # Deduplicate by magnet hash (preferring the first occurrence, which has higher seeds after sort)
+    seen_hashes: set[str] = set()
+    seen_links: set[str] = set()
+    deduped: List[Dict[str, Any]] = []
+    for r in results:
+        magnet = r.get("magnet")
+        link = r.get("torrent_link")
+        key_hash: str | None = None
+        if magnet:
+            with contextlib.suppress(Exception):
+                key_hash = torrent.get_hash(magnet).lower()
+        if key_hash:
+            if key_hash in seen_hashes:
+                continue
+            seen_hashes.add(key_hash)
+        elif link:
+            if link in seen_links:
+                continue
+            seen_links.add(link)
+        deduped.append(r)
+
+    return sorted(deduped, key=lambda x: x.get("seeds", 0) or 0, reverse=True)
+
+
 @app.get("/health")
 def health() -> Dict[str, bool]:
     return {"ok": daemon.thread.is_alive()}
@@ -309,19 +345,17 @@ def _add_status_to_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]
 @app.get("/api/search/", response_model=SearchResponse)
 @app.get("/api/search/{searchterm}", response_model=SearchResponse)
 def search(searchterm: str = "", _: None = Depends(authorize)) -> Dict[str, Any]:
-    if settings.JACKETT_HOST:
-        results: List[Dict[str, Any]] = jackett.search(searchterm)
-        # Filter out results without magnet or torrent_link
-        results = [r for r in results if r.get("magnet") or r.get("torrent_link")]
+    if settings.JACKETT_HOST or settings.PROWLARR_HOST:
+        results: List[Dict[str, Any]] = _indexer_search(searchterm)
     else:
         results = [
             {
-                "title": "NO JACKETT SERVER CONFIGURED",
+                "title": "NO SEARCH BACKEND CONFIGURED",
                 "seeds": 1337,
                 "magnet": "N/A"
             },
             {
-                "title": "Please connect Jackett using the config variables JACKETT_HOST and JACKETT_API_KEY",
+                "title": "Please connect Jackett (JACKETT_HOST/JACKETT_API_KEY) or Prowlarr (PROWLARR_HOST/PROWLARR_API_KEY)",
                 "seeds": 1337,
                 "magnet": "N/A"
             }
@@ -430,7 +464,7 @@ def _torrent_url_to_magnet(torrent_url: str) -> str | None:
     magnet_link: str | None = None
     try:
         r: requests.Response = requests.get(torrent_url, allow_redirects=False, timeout=30)
-        if r.status_code == 302:
+        if r.status_code in (301, 302, 303, 307, 308):
             location: str | None = r.headers.get("Location")
             if location and location.startswith("magnet"):
                 _save_torrent_url_to_cache(torrent_url, location)
@@ -515,8 +549,7 @@ def next_file(magnet_hash: str, filename: str, _: None = Depends(authorize)) -> 
                         search_term += f" {resolution}"
                     if codec:
                         search_term += f" {codec}"
-                    results: List[Dict[str, Any]] = jackett.search(search_term) if settings.JACKETT_HOST else []
-                    results = [r for r in results if r.get("magnet") or r.get("torrent_link")]
+                    results: List[Dict[str, Any]] = _indexer_search(search_term)
                     if results:
                         result = results[0]
                         next_magnet = result.get("magnet")

--- a/app/prowlarr.py
+++ b/app/prowlarr.py
@@ -1,0 +1,126 @@
+import re
+from typing import Any, Dict, List
+
+import log
+import requests
+import settings
+import torrent
+from common import memoize
+from dateutil.parser import parse
+
+API_PATH = f"{settings.PROWLARR_HOST}/api/v1"
+API_KEY = settings.PROWLARR_API_KEY
+
+
+def _extract_magnet(result: Dict[str, Any]) -> str | None:
+    """Return a real magnet: URI from a Prowlarr result, if one is directly available.
+
+    Prowlarr's `magnetUrl` is often its own proxy URL that 302-redirects to the
+    actual magnet, so it's not a magnet by itself. The real magnet is usually
+    in `guid` for indexers like ThePirateBay; for others, we fall back to
+    constructing one from `infoHash` if present.
+    """
+    for key in ("magnetUrl", "guid"):
+        v = result.get(key)
+        if isinstance(v, str) and v.startswith("magnet:?xt=urn:btih:"):
+            return v
+    info_hash = result.get("infoHash")
+    title = result.get("title")
+    if isinstance(info_hash, str) and info_hash and isinstance(title, str):
+        from urllib.parse import quote
+        return f"magnet:?xt=urn:btih:{info_hash.lower()}&dn={quote(title)}"
+    return None
+
+
+def _extract_torrent_link(result: Dict[str, Any]) -> str | None:
+    """Return a URL the daemon can download/redirect-resolve to obtain the torrent."""
+    for key in ("downloadUrl", "magnetUrl"):
+        v = result.get(key)
+        if isinstance(v, str) and v and not v.startswith("magnet:"):
+            return v
+    guid = result.get("guid")
+    if isinstance(guid, str) and guid.startswith(("http://", "https://")):
+        return guid
+    return None
+
+
+@memoize(300)
+def search(searchterm: str) -> List[Dict[str, int | str | Any | None]]:
+    magnet_links: List[Dict[str, int | str | Any | None]] = []
+    try:
+        params = {
+            "query": searchterm,
+            "type": "search",
+            "limit": 100,
+            "apikey": API_KEY,
+        }
+        headers = {"X-Api-Key": API_KEY}
+        resp = requests.get(
+            f"{API_PATH}/search", params=params, headers=headers, timeout=15
+        )
+        results: List[Dict[str, Any]] = resp.json() or []
+
+        # Prowlarr can also return usenet results; only torrents are usable here
+        results = [
+            r for r in results if r.get("protocol", "torrent") == "torrent"
+        ]
+
+        results = sorted(results, key=lambda x: x.get("seeders", 0) or 0, reverse=True)
+
+        pattern = re.compile(r"\s(s\d\d)(e\d\d)?")
+        season = None
+        episode = None
+        match = pattern.search(searchterm.lower())
+        if match:
+            season = match.group(1)
+            episode = match.group(2)
+
+        if season and (episode is None):
+
+            def sort_by_only_season(x: Dict[str, Any]) -> int:
+                episode_pattern = re.compile(r"[eE]\d\d")
+                return 0 if episode_pattern.search(x.get("title", "")) else 1
+
+            results = sorted(results, key=sort_by_only_season, reverse=True)
+
+        hashes: List[str] = []
+
+        for result in results:
+            indexer = result.get("indexer") or ""
+            if (
+                searchterm == ""
+                and indexer in settings.EXCLUDE_TRACKERS_FROM_TRENDING
+            ):
+                continue
+            title = result.get("title")
+            if not title:
+                continue
+
+            magnet_uri = _extract_magnet(result)
+            torrent_link = _extract_torrent_link(result)
+            if not (magnet_uri or torrent_link):
+                continue
+
+            if magnet_uri:
+                magnet_hash = torrent.get_hash(magnet_uri)
+                if magnet_hash in hashes:
+                    continue
+                hashes.append(magnet_hash)
+
+            if (result.get("seeders") or 0) == 0:
+                continue
+
+            published = result.get("publishDate")
+            magnet_links.append(
+                {
+                    "seeds": result.get("seeders", 0) or 0,
+                    "title": title,
+                    "magnet": magnet_uri,
+                    "torrent_link": torrent_link,
+                    "published": parse(published) if published else None,
+                }
+            )
+    except (requests.RequestException, KeyError, ValueError) as e:
+        log.write_log()
+        log.debug(f"Prowlarr search failed: {e}")
+    return magnet_links

--- a/app/prowlarr.py
+++ b/app/prowlarr.py
@@ -48,17 +48,21 @@ def _extract_torrent_link(result: Dict[str, Any]) -> str | None:
 def search(searchterm: str) -> List[Dict[str, int | str | Any | None]]:
     magnet_links: List[Dict[str, int | str | Any | None]] = []
     try:
-        params = {
+        params: Dict[str, str] = {
             "query": searchterm,
             "type": "search",
-            "limit": 100,
-            "apikey": API_KEY,
+            "limit": "100",
         }
-        headers = {"X-Api-Key": API_KEY}
+        headers: Dict[str, str] = {"X-Api-Key": API_KEY}
         resp = requests.get(
             f"{API_PATH}/search", params=params, headers=headers, timeout=15
         )
-        results: List[Dict[str, Any]] = resp.json() or []
+        resp.raise_for_status()
+        data: Any = resp.json()
+        if not isinstance(data, list):
+            log.debug(f"Prowlarr returned unexpected payload (status={resp.status_code}): {data!r:.200}")
+            return magnet_links
+        results: List[Dict[str, Any]] = [r for r in data if isinstance(r, dict)]  # type: ignore[reportUnknownVariableType]
 
         # Prowlarr can also return usenet results; only torrents are usable here
         results = [

--- a/app/settings.py
+++ b/app/settings.py
@@ -22,6 +22,10 @@ _kodi_addon_dir: str = "./app/kodi.addon"
 JACKETT_HOST: str | None = None
 JACKETT_API_KEY: str = ""
 
+# PROWLARR
+PROWLARR_HOST: str | None = None
+PROWLARR_API_KEY: str = ""
+
 # TORRENT
 TORRENT_LISTENING_PORT: int | None = None
 DHT_ROUTERS: List[Tuple[str, int]] = [

--- a/docker-compose.example.with.prowlarr.yml
+++ b/docker-compose.example.with.prowlarr.yml
@@ -1,0 +1,19 @@
+version: "3"
+
+services:
+    prowlarr:
+        image: linuxserver/prowlarr
+        ports:
+            - 9696:9696
+        volumes:
+            - ./.prowlarr:/config
+
+    rapidbay:
+        image: hauxir/rapidbay:latest
+        environment:
+            - PROWLARR_HOST=http://prowlarr:9696
+            - PROWLARR_API_KEY=YOUR_API_KEY
+        ports:
+            - 5000:5000
+        links:
+            - prowlarr


### PR DESCRIPTION
## Summary
- Adds a new `prowlarr` module that queries Prowlarr's `/api/v1/search` API and normalizes results into the same shape as the existing Jackett backend
- Wires Prowlarr in alongside Jackett via new `PROWLARR_HOST`/`PROWLARR_API_KEY` settings; both backends can run simultaneously, with results merged and deduplicated by magnet hash (or torrent_link when no magnet is exposed)
- Extends `_torrent_url_to_magnet` to follow 301/303/307/308 redirects in addition to 302 — Prowlarr's proxy URL uses a 301 to redirect to the actual magnet, which the previous code wouldn't follow
- Adds `docker-compose.example.with.prowlarr.yml` and updates the README to document the new backend

## How Prowlarr results are mapped
Prowlarr exposes the actual magnet URI in different fields depending on the indexer (often `guid` for indexers like ThePirateBay/UIndex/EZTV; only a proxy `magnetUrl`/`downloadUrl` for others like RuTracker). The new module:
- Pulls a real `magnet:?xt=urn:btih:...` URI when Prowlarr exposes one directly, falling back to constructing one from `infoHash` if available
- Always sets `torrent_link` to the Prowlarr proxy URL so results without a direct magnet still resolve via the existing 301-redirect path

## Test plan
Tested live against an external Prowlarr instance:
- [x] `prowlarr.search("ubuntu")` returns 152 results across 4 indexers (TPB, UIndex, EZTV, RuTracker); 95/95 results in a `debian` query had a parseable info hash or a working torrent_link
- [x] Magnet-bearing results 301-redirect from the Prowlarr proxy to the real magnet URI (validated end-to-end with `_torrent_url_to_magnet`)
- [x] Results without direct magnets (RuTracker) serve a real `application/x-bittorrent` payload via the proxy URL, which the existing torrent-file path handles
- [x] `ruff check` passes; `pytest` passes (1/1)
- [ ] Manual sanity check via the web UI with `PROWLARR_HOST`/`PROWLARR_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)