### PR TITLE
Stop force_recheck from blocking RD downloads

### DIFF
--- a/app/rapidbaydaemon.py
+++ b/app/rapidbaydaemon.py
@@ -260,12 +260,7 @@ class RapidBayDaemon:
             http_progress = self.http_downloader.downloads.get(download_path, 0)
 
             # If HTTP download is complete, trust that over torrent progress
-            if http_progress == 1:
-                download_progress = 1
-                # Trigger recheck but don't wait for it - let heartbeat handle it
-                h.force_recheck()
-            else:
-                download_progress = max(http_progress, download_progress)
+            download_progress = 1 if http_progress == 1 else max(http_progress, download_progress)
 
         if download_progress == 1:
             if filename_extension[1:] in settings.VIDEO_EXTENSIONS:
@@ -329,22 +324,12 @@ class RapidBayDaemon:
                 self.http_downloader.clear(filepath)
             return
 
-        # Check if any HTTP downloads are active and trigger recheck
-        needs_recheck = False
         for i, f in enumerate(files):
             filepath = os.path.join(settings.DOWNLOAD_DIR, magnet_hash, f.path)
-            http_progress = self.http_downloader.downloads.get(filepath, -1)
-            if http_progress > 0:
-                needs_recheck = True
-                if http_progress == 1:
-                    # Only clear HTTP tracking if torrent now recognizes the file as complete
-                    torrent_progress = h.file_progress()[i] / f.size if f.size > 0 else 0
-                    if torrent_progress >= 0.99:  # Allow for small rounding errors
-                        self.http_downloader.clear(filepath)
-                        log.debug(f"HTTP cache download completed and recognized by torrent for {filepath}")
-
-        if needs_recheck:
-            h.force_recheck()
+            if self.http_downloader.downloads.get(filepath, -1) == 1:
+                torrent_progress = h.file_progress()[i] / f.size if f.size > 0 else 0
+                if torrent_progress >= 0.99:
+                    self.http_downloader.clear(filepath)
 
         for f in files:
             filename = os.path.basename(f.path)

--- a/app/rapidbaydaemon.py
+++ b/app/rapidbaydaemon.py
@@ -324,10 +324,16 @@ class RapidBayDaemon:
                 self.http_downloader.clear(filepath)
             return
 
-        for i, f in enumerate(files):
+        # Iterate over the unfiltered torrent files so `file_progress` indexing
+        # matches libtorrent's view; the `files` list above is filtered by
+        # priority and its indices don't line up.
+        file_progress = h.file_progress()
+        for i, f in enumerate(torrent.get_torrent_info(h).files()):
+            if file_priorities[i] == 0:
+                continue
             filepath = os.path.join(settings.DOWNLOAD_DIR, magnet_hash, f.path)
             if self.http_downloader.downloads.get(filepath, -1) == 1:
-                torrent_progress = h.file_progress()[i] / f.size if f.size > 0 else 0
+                torrent_progress = file_progress[i] / f.size if f.size > 0 else 0
                 if torrent_progress >= 0.99:
                     self.http_downloader.clear(filepath)
 


### PR DESCRIPTION
## Summary

- `get_file_status` was calling `h.force_recheck()` on every status poll where `http_progress == 1`, and `_handle_torrent` was calling it on every heartbeat where any HTTP download was in progress (`http_progress > 0`). Both fire continuously while polling, making libtorrent re-hash the entire file on disk over and over.
- The full-file SHA1 read competes with ffmpeg conversion for disk I/O, which hides Real-Debrid's speed advantage behind a long post-100% pause — the "status page shows fast download but it's still slow" symptom.
- Drop both `force_recheck` calls. `get_file_status` already advances state on `http_progress == 1`, and `urllib.request.urlretrieve` raises `ContentTooShortError` when the response is truncated, which covers the realistic RD failure mode (short response, dropped connection, error page in place of bytes). HTTPS handles in-flight integrity. The parallel libtorrent download is unchanged, so an HTTP failure still falls back to peers.

## Test plan

- [ ] Trigger a download for a magnet that RD has cached and confirm there is no extended pause between `downloading (100%)` and `converting`.
- [ ] Confirm the resulting MP4 plays correctly end-to-end (no integrity regression from dropping the recheck).
- [ ] Verify `ruff check app/rapidbaydaemon.py` and `basedpyright app/rapidbaydaemon.py` both pass.
- [ ] Sanity-check that an HTTP failure (e.g. revoked RD URL) still completes via the parallel torrent download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)