### PR TITLE
Use ffprobe for codec detection in MP4 conversion

### DIFF
--- a/app/video_conversion.py
+++ b/app/video_conversion.py
@@ -2,8 +2,9 @@ import contextlib
 import datetime
 import os
 import re
+import subprocess
 import time
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 from typing import Any, Dict, List, Tuple
 
 import log
@@ -53,20 +54,50 @@ def _extract_subtitles_as_vtt(filepath: str) -> Any:
     )
 
 
+def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> List[str]:
+    """Returns ffprobe `codec_name` for every stream of the given type
+    ("a" for audio, "v" for video). Empty list if ffprobe fails or finds no
+    matching streams."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-select_streams", stream_type,
+                "-show_entries", "stream=codec_name",
+                "-of", "default=nw=1:nk=1",
+                filepath,
+            ],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        return [c.strip().lower() for c in result.stdout.splitlines() if c.strip()]
+    except (TimeoutExpired, OSError):
+        return []
+
+
+def _video_codec_passthrough(codec: str) -> bool:
+    """True when the video codec is browser-compatible inside MP4 and can be
+    stream-copied. Matches both ffprobe `codec_name` ("h264", "hevc") and
+    MediaInfo `format` ("AVC", "HEVC")."""
+    return any(s in codec for s in ("h264", "h265", "avc", "hevc", "av1"))
+
+
 def _convert_file_to_mp4(input_filepath: str, output_filepath: str, subtitle_filepaths: List[Tuple[str | None, str]] | None = None) -> Any:
     if subtitle_filepaths is None:
         subtitle_filepaths = []
     output_extension: str = os.path.splitext(output_filepath)[1]
     media_info: Any = MediaInfo.parse(input_filepath)
-    audio_codecs: List[str] = [
-        t.format.lower() for t in media_info.tracks if t.track_type == "Audio"
-    ]
-    video_codecs: List[str] = [
-        t.format.lower() for t in media_info.tracks if t.track_type == "Video"
-    ]
-    needs_audio_conversion: bool = not any("aac" in c for c in audio_codecs)
-    needs_video_conversion: bool = settings.CONVERT_VIDEO and not any(("avc" in c or "hevc" in c or "av1" in c) for c in video_codecs)
-    is_hevc: bool = any(("hevc" in c) for c in video_codecs)
+    # Codec detection via ffprobe — MediaInfo's `format` strings vary across
+    # containers (e.g. "AAC LC", "MPEG-4 Audio") and miss codecs entirely on
+    # partial/unusual files, which would force a needless transcode.
+    audio_codecs: List[str] = _ffprobe_stream_codecs(input_filepath, "a")
+    video_codecs: List[str] = _ffprobe_stream_codecs(input_filepath, "v")
+    needs_audio_conversion: bool = bool(audio_codecs) and not any("aac" in c for c in audio_codecs)
+    needs_video_conversion: bool = (
+        settings.CONVERT_VIDEO
+        and bool(video_codecs)
+        and not any(_video_codec_passthrough(c) for c in video_codecs)
+    )
+    is_hevc: bool = any(("hevc" in c or "h265" in c) for c in video_codecs)
     has_picture_subs: bool = (
         len(
             [

--- a/app/video_conversion.py
+++ b/app/video_conversion.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 import time
 from subprocess import Popen, TimeoutExpired
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import log
 import settings
@@ -54,10 +54,11 @@ def _extract_subtitles_as_vtt(filepath: str) -> Any:
     )
 
 
-def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> List[str]:
+def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> Optional[List[str]]:
     """Returns ffprobe `codec_name` for every stream of the given type
-    ("a" for audio, "v" for video). Empty list if ffprobe fails or finds no
-    matching streams."""
+    ("a" for audio, "v" for video). Returns `None` when ffprobe fails (timeout,
+    missing binary, non-zero exit) so callers can distinguish probe failure
+    from a file that genuinely has no streams of that type."""
     try:
         result = subprocess.run(
             [
@@ -69,15 +70,23 @@ def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> List[str]:
             ],
             capture_output=True, text=True, timeout=15, check=False,
         )
-        return [c.strip().lower() for c in result.stdout.splitlines() if c.strip()]
-    except (TimeoutExpired, OSError):
-        return []
+    except (TimeoutExpired, OSError) as e:
+        log.debug(f"ffprobe failed for {filepath} ({stream_type}): {e}")
+        return None
+    if result.returncode != 0:
+        log.debug(
+            f"ffprobe non-zero exit ({result.returncode}) for {filepath} "
+            f"({stream_type}): {result.stderr.strip()}"
+        )
+        return None
+    return [c.strip().lower() for c in result.stdout.splitlines() if c.strip()]
 
 
 def _video_codec_passthrough(codec: str) -> bool:
     """True when the video codec is browser-compatible inside MP4 and can be
-    stream-copied. Matches both ffprobe `codec_name` ("h264", "hevc") and
+    stream-copied. Accepts both ffprobe `codec_name` ("h264", "hevc") and
     MediaInfo `format` ("AVC", "HEVC")."""
+    codec = codec.lower()
     return any(s in codec for s in ("h264", "h265", "avc", "hevc", "av1"))
 
 
@@ -88,9 +97,18 @@ def _convert_file_to_mp4(input_filepath: str, output_filepath: str, subtitle_fil
     media_info: Any = MediaInfo.parse(input_filepath)
     # Codec detection via ffprobe — MediaInfo's `format` strings vary across
     # containers (e.g. "AAC LC", "MPEG-4 Audio") and miss codecs entirely on
-    # partial/unusual files, which would force a needless transcode.
-    audio_codecs: List[str] = _ffprobe_stream_codecs(input_filepath, "a")
-    video_codecs: List[str] = _ffprobe_stream_codecs(input_filepath, "v")
+    # partial/unusual files, which would force a needless transcode. Fall back
+    # to MediaInfo if ffprobe is unavailable or errors out.
+    audio_codecs: Optional[List[str]] = _ffprobe_stream_codecs(input_filepath, "a")
+    video_codecs: Optional[List[str]] = _ffprobe_stream_codecs(input_filepath, "v")
+    if audio_codecs is None:
+        audio_codecs = [
+            t.format.lower() for t in media_info.tracks if t.track_type == "Audio" and t.format
+        ]
+    if video_codecs is None:
+        video_codecs = [
+            t.format.lower() for t in media_info.tracks if t.track_type == "Video" and t.format
+        ]
     needs_audio_conversion: bool = bool(audio_codecs) and not any("aac" in c for c in audio_codecs)
     needs_video_conversion: bool = (
         settings.CONVERT_VIDEO

--- a/app/video_conversion.py
+++ b/app/video_conversion.py
@@ -5,7 +5,7 @@ import re
 import subprocess
 import time
 from subprocess import Popen, TimeoutExpired
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import log
 import settings
@@ -54,7 +54,7 @@ def _extract_subtitles_as_vtt(filepath: str) -> Any:
     )
 
 
-def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> Optional[List[str]]:
+def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> List[str] | None:
     """Returns ffprobe `codec_name` for every stream of the given type
     ("a" for audio, "v" for video). Returns `None` when ffprobe fails (timeout,
     missing binary, non-zero exit) so callers can distinguish probe failure
@@ -75,8 +75,7 @@ def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> Optional[List[str
         return None
     if result.returncode != 0:
         log.debug(
-            f"ffprobe non-zero exit ({result.returncode}) for {filepath} "
-            f"({stream_type}): {result.stderr.strip()}"
+            f"ffprobe non-zero exit ({result.returncode}) for {filepath} ({stream_type}): {result.stderr.strip()}"
         )
         return None
     return [c.strip().lower() for c in result.stdout.splitlines() if c.strip()]
@@ -99,8 +98,8 @@ def _convert_file_to_mp4(input_filepath: str, output_filepath: str, subtitle_fil
     # containers (e.g. "AAC LC", "MPEG-4 Audio") and miss codecs entirely on
     # partial/unusual files, which would force a needless transcode. Fall back
     # to MediaInfo if ffprobe is unavailable or errors out.
-    audio_codecs: Optional[List[str]] = _ffprobe_stream_codecs(input_filepath, "a")
-    video_codecs: Optional[List[str]] = _ffprobe_stream_codecs(input_filepath, "v")
+    audio_codecs: List[str] | None = _ffprobe_stream_codecs(input_filepath, "a")
+    video_codecs: List[str] | None = _ffprobe_stream_codecs(input_filepath, "v")
     if audio_codecs is None:
         audio_codecs = [
             t.format.lower() for t in media_info.tracks if t.track_type == "Audio" and t.format


### PR DESCRIPTION
## Summary

- MediaInfo's `format` strings are inconsistent across containers (AAC shows up as `AAC`, `AAC LC`, `HE-AAC`, `MPEG-4 Audio`, …). The substring check `"aac" in t.format.lower()` mostly works but breaks for cases where MediaInfo reports the audio as something less obvious, or fails to parse the file at all (partial / unusual containers, missing tracks).
- Both failure modes silently force `-acodec aac` and re-encode an already-AAC track. Same hazard exists on the video side with `"avc"`/`"hevc"`/`"av1"` substring matching against MediaInfo's `format`.
- Switch detection in `_convert_file_to_mp4` to ffprobe's `codec_name`, which is stable and consistent ("aac", "h264", "hevc"). Skip the re-encode entirely when ffprobe finds no streams of that type — there's nothing to encode anyway.
- Added a small `_video_codec_passthrough` helper that matches both ffprobe (`h264`, `hevc`) and MediaInfo (`AVC`, `HEVC`) names, so the check stays correct through the existing fallback paths.

## Test plan

- [ ] Run a conversion on a file whose source audio is already AAC (e.g. an MP4 release). The ffmpeg invocation should include `-acodec copy`, not `-acodec aac`.
- [ ] Run a conversion on a file with AC3/DTS audio. The ffmpeg invocation should include `-acodec aac` (re-encode is required).
- [ ] Run a conversion on a file whose source video is already H.264. The ffmpeg invocation should include `-vcodec copy`, not `-vcodec libx264 …`.
- [ ] Verify `ruff check app/video_conversion.py` and `basedpyright app/video_conversion.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)