### PR TITLE
Fix stuck RD downloads from filelist path mismatch

### DIFF
--- a/app/rapidbaydaemon.py
+++ b/app/rapidbaydaemon.py
@@ -202,6 +202,21 @@ class RapidBayDaemon:
         ]:
             return
 
+        # Add to libtorrent first so the on-disk filelist is rewritten with
+        # libtorrent's view of file paths before we compute the HTTP target.
+        # An RD-supplied filelist can list a file as `inner.mkv` while
+        # libtorrent stores it at `<torrent_name>/inner.mkv` for multi-file
+        # torrents. If the HTTP download key was computed from the RD view
+        # but get_file_status later resolves the path against libtorrent's
+        # view, the http_progress lookup misses and the file stalls in
+        # DOWNLOADING — libtorrent's own progress is pinned at 0 once we
+        # set this file's priority to 0 below.
+        self.torrent_client.download_file(magnet_link, filename)
+
+        h = self.torrent_client.torrents.get(magnet_hash)
+        h.set_download_limit(settings.TORRENT_DOWNLOAD_LIMIT)  # type: ignore
+        h.set_upload_limit(settings.TORRENT_UPLOAD_LIMIT)  # type: ignore
+
         download_path = _get_download_path(magnet_hash, filename)
 
         using_http = False
@@ -213,12 +228,6 @@ class RapidBayDaemon:
                 if cached_url:
                     self.http_downloader.download_file(cached_url, download_path)
                     using_http = True
-
-        self.torrent_client.download_file(magnet_link, filename)
-
-        h = self.torrent_client.torrents.get(magnet_hash)
-        h.set_download_limit(settings.TORRENT_DOWNLOAD_LIMIT)  # type: ignore
-        h.set_upload_limit(settings.TORRENT_UPLOAD_LIMIT)  # type: ignore
 
         # Stop libtorrent from also fetching this file from peers — concurrent
         # writes between urlretrieve and libtorrent corrupted the file in


### PR DESCRIPTION
## Summary

- Fixes an RD-downloaded file getting stuck in `DOWNLOADING` (progress 0) for multi-file torrents, even after `urlretrieve` finishes.
- Reorders `RapidBayDaemon.download_file` so libtorrent establishes the authoritative on-disk filelist before we compute the HTTP target path.

## Root cause

`download_file` previously read the filelist (RD-supplied at this point) to compute `download_path`, then started the HTTP download keyed by that path, then called `torrent_client.download_file` — which calls `_write_filelist_to_disk`, overwriting the filelist with libtorrent's view. For multi-file torrents the two views disagree:

| Source | Stored path |
| --- | --- |
| RD `get_filelist` | `Inner.mkv` |
| libtorrent `f.path` | `<torrent_name>/Inner.mkv` |

Once the filelist is replaced, `get_file_status` calls `_get_download_path` and gets the with-parent path, so `http_downloader.downloads.get(...)` misses (returns 0). With the file's libtorrent priority pinned at 0 (so peers don't race the HTTP write), `download_progress` is also 0, and the state machine never advances past `DOWNLOADING`.

This was masked before #59 because `force_recheck` was firing on every poll, but rechecking didn't actually rescue this case either — the HTTP write lives at a different on-disk path than libtorrent's allocation. Removing it just made the stall visible without the disk-I/O cost.

## Fix

Run `torrent_client.download_file(...)` first so `_write_filelist_to_disk` establishes libtorrent's paths, then call `_get_download_path` to compute the HTTP target. Both `download_file` and `get_file_status` now resolve to the same key, the `http_progress == 1` branch fires, and the daemon advances to subtitle download / conversion as intended.

## Test plan

- [ ] On a multi-file torrent (e.g. `Widows.Bay.S01E02.1080p.WEB.h264-GRACE` where libtorrent allocates under a `www.UIndex.org - …` parent dir), confirm with `RD_TOKEN` set that the file transitions out of `DOWNLOADING` once `urlretrieve` completes.
- [ ] Single-file torrent path (RD path == libtorrent path) still works end-to-end.
- [ ] Non-RD path (no `cached_url`) — pure libtorrent download still progresses.
- [ ] `ci.sh` (basedpyright + ruff + smoke import + pytest) — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)