### PR TITLE
Raise AAC bitrate to 256k and use the fast AAC coder

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -50,7 +50,7 @@ SUBTITLE_LANGUAGES: List[str] = ["en"]  # list of languages, e.g. ["en", "de", "
 # CONVERSION
 CONVERT_VIDEO: bool = True
 VIDEO_CONVERSION_PARAMS: str = "libx264 -preset ultrafast"
-AAC_BITRATE: str = "128k"
+AAC_BITRATE: str = "256k"
 AAC_CHANNELS: int = 2
 INCOMPLETE_POSTFIX: str = ".incomplete"
 LOG_POSTFIX: str = ".log"

--- a/app/video_conversion.py
+++ b/app/video_conversion.py
@@ -149,7 +149,7 @@ def _convert_file_to_mp4(input_filepath: str, output_filepath: str, subtitle_fil
                 "-map 0:v?",
                 "-map 0:a?",
                 "-map 0:s?" if n_sub_tracks > 0 else "",
-                f"-acodec aac -ab {settings.AAC_BITRATE} -ac {settings.AAC_CHANNELS}"
+                f"-acodec aac -aac_coder fast -ab {settings.AAC_BITRATE} -ac {settings.AAC_CHANNELS}"
                 if needs_audio_conversion
                 else "-acodec copy",
                 "-vcodec " + settings.VIDEO_CONVERSION_PARAMS


### PR DESCRIPTION
## Summary
- Bump default `AAC_BITRATE` from 128k to 256k for better audio quality
- Pass `-aac_coder fast` to MP4 conversion so the higher bitrate doesn't slow down encoding

## Changes
- `app/settings.py` — default bitrate 128k → 256k
- `app/video_conversion.py` — add `-aac_coder fast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)