### PR TITLE
Report download source (HTTP vs torrent) and download rate

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -57,6 +57,8 @@ class FileStatusResponse(BaseModel):
     supported: bool | None = None
     progress: float | None = None
     peers: int | None = None
+    source: str | None = None
+    download_rate: int | None = None
 
 
 class NextFileResponse(BaseModel):

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -988,10 +988,19 @@
                                   Math.round(data.progress * 100) +
                                   "%)"
                                 : text;
-                        self.subheading =
-                            data.peers === 0 || data.peers
-                                ? data.peers + " Peers"
-                                : null;
+                        var subheadingParts = [];
+                        if (data.source === "http") {
+                            subheadingParts.push("HTTP");
+                        } else if (data.peers === 0 || data.peers) {
+                            subheadingParts.push(data.peers + " Peers");
+                        }
+                        if (data.download_rate) {
+                            var mbps = (data.download_rate / 1000000).toFixed(2);
+                            subheadingParts.push(mbps + " MB/s");
+                        }
+                        self.subheading = subheadingParts.length
+                            ? subheadingParts.join(" · ")
+                            : null;
                         self.play_link = data.filename
                             ? "/play/" +
                               magnet_hash +

--- a/app/frontend/app.kodi.py
+++ b/app/frontend/app.kodi.py
@@ -130,10 +130,13 @@ def play(magnet_link, filename):
         status_str = status.get("status")
         progress_percentage = int(status.get("progress", 0) * 100)
         peers = status.get("peers")
+        source = status.get("source")
         if status_str != "ready":
             if progress_percentage > 0:
                 status_str = status_str + f" ({progress_percentage}%)"
-            if peers is not None:
+            if source == "http":
+                status_str = status_str + ", HTTP"
+            elif peers is not None:
                 status_str = status_str + f", {peers} peers"
         status_str = status_str.replace("_", " ").title()
         progress.update(progress_percentage, status_str)

--- a/app/http_downloader.py
+++ b/app/http_downloader.py
@@ -1,7 +1,8 @@
 import contextlib
 import os
+import time
 import urllib.request
-from typing import Dict, Set
+from typing import Dict, Set, Tuple
 
 import log
 from common import threaded
@@ -10,6 +11,8 @@ from common import threaded
 class HttpDownloader:
     def __init__(self) -> None:
         self.downloads: Dict[str, float] = {}
+        self.download_rates: Dict[str, int] = {}
+        self._rate_samples: Dict[str, Tuple[float, int]] = {}
         # Output paths whose urlretrieve raised. The daemon drains this each
         # heartbeat to fail over to libtorrent for the affected file.
         self.failures: Set[str] = set()
@@ -17,11 +20,14 @@ class HttpDownloader:
     def clear(self, output_path: str) -> None:
         with contextlib.suppress(KeyError):
             del self.downloads[output_path]
+        self.download_rates.pop(output_path, None)
+        self._rate_samples.pop(output_path, None)
 
     def download_file(self, url: str, output_path: str) -> None:
         if self.downloads.get(output_path):
             return
         self.downloads[output_path] = 0
+        self._rate_samples[output_path] = (time.monotonic(), 0)
         self._urlretrieve(url, output_path)
 
     @threaded
@@ -29,10 +35,17 @@ class HttpDownloader:
     def _urlretrieve(self, url: str, output_path: str) -> None:
         def progress(block_num: int, block_size: int, total_size: int) -> None:
             downloaded = block_num * block_size
+            now = time.monotonic()
+            last_time, last_bytes = self._rate_samples.get(output_path, (now, downloaded))
+            elapsed = now - last_time
+            if elapsed >= 0.5:
+                self.download_rates[output_path] = max(0, int((downloaded - last_bytes) / elapsed))
+                self._rate_samples[output_path] = (now, downloaded)
             if downloaded < total_size:
                 self.downloads[output_path] = downloaded / total_size
             else:
                 self.downloads[output_path] = 1
+                self.download_rates[output_path] = 0
 
         dirname = os.path.dirname(output_path)
         os.makedirs(dirname, exist_ok=True)
@@ -40,5 +53,7 @@ class HttpDownloader:
             urllib.request.urlretrieve(url, output_path, progress)
         except Exception:
             self.downloads.pop(output_path, None)
+            self.download_rates.pop(output_path, None)
+            self._rate_samples.pop(output_path, None)
             self.failures.add(output_path)
             raise

--- a/app/rapidbaydaemon.py
+++ b/app/rapidbaydaemon.py
@@ -321,10 +321,17 @@ class RapidBayDaemon:
             else:
                 return {'status': FileStatus.READY_TO_COPY}
             return {'status': FileStatus.DOWNLOAD_FINISHED}
+        torrent_status = h.status()
+        download_rate = torrent_status.download_rate
+        if download_path:
+            download_rate += self.http_downloader.download_rates.get(download_path, 0)
+        is_http = filename in self._http_served.get(magnet_hash, set())
         return {
             'status': FileStatus.DOWNLOADING,
             'progress': download_progress,
-            'peers': h.status().num_peers,
+            'peers': None if is_http else torrent_status.num_peers,
+            'source': 'http' if is_http else 'torrent',
+            'download_rate': download_rate,
         }
 
     def _download_external_subtitles(self, filepath: str, skip: List[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
Surface in the file status whether a file is being served over HTTP or torrent, plus the current download rate.

## Changes
- `HttpDownloader` tracks a per-file byte rate over a ≥0.5s window
- The daemon sums HTTP + torrent rates and tags the source; `peers` is nulled for HTTP-served files
- Web UI shows "HTTP" / "N Peers" plus "X.XX MB/s" in the subheading
- Kodi frontend appends ", HTTP" or ", N peers" to the status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)