### PR TITLE
Stream debrid files to libtorrent as BEP19 web seeds via local proxy

### DIFF
--- a/app/http_cache/__init__.py
+++ b/app/http_cache/__init__.py
@@ -2,7 +2,10 @@ from typing import List
 
 from . import real_debrid, torbox
 
-_providers = [real_debrid, torbox]
+# TorBox first: Real Debrid DMCA-blocks (HTTP 451) most popular content, so it
+# answers far less often than TorBox and a failed RD lookup just adds latency.
+# RD stays as a fallback for the occasional title TorBox lacks.
+_providers = [torbox, real_debrid]
 
 
 def get_cached_url(magnet_hash: str, filename: str) -> str | None:

--- a/app/rapidbaydaemon.py
+++ b/app/rapidbaydaemon.py
@@ -12,6 +12,7 @@ import settings
 import subtitles
 import torrent
 import video_conversion
+import web_seed_proxy
 from common import normalize_filename, threaded
 from http_downloader import HttpDownloader
 from subtitles import get_subtitle_language
@@ -149,6 +150,11 @@ class RapidBayDaemon:
         # "user-selected", which would otherwise drop these files from
         # `active_filenames` and remove the torrent (with files) mid-download.
         self._http_served: Dict[str, Set[str]] = {}
+        # Files handed to libtorrent as web seeds (BEP19). Unlike _http_served
+        # these keep normal libtorrent priority — libtorrent is the sole writer
+        # and fetches the file from the web seed and/or peers transparently.
+        # Tracked only so get_file_status can report the source as HTTP.
+        self._web_seeded: Dict[str, Set[str]] = {}
         self._stop_event: Event = Event()
         self.thread: Thread = Thread(target=self._loop_wrapper, args=())
         self.thread.daemon = True
@@ -217,34 +223,24 @@ class RapidBayDaemon:
         h.set_download_limit(settings.TORRENT_DOWNLOAD_LIMIT)  # type: ignore
         h.set_upload_limit(settings.TORRENT_UPLOAD_LIMIT)  # type: ignore
 
-        download_path = _get_download_path(magnet_hash, filename)
-
-        using_http = False
-        if download_path:
-            if self.http_downloader.downloads.get(download_path) is not None:
-                using_http = True
-            else:
-                cached_url = http_cache.get_cached_url(magnet_hash, filename)
-                if cached_url:
-                    self.http_downloader.download_file(cached_url, download_path)
-                    using_http = True
-
-        # Stop libtorrent from also fetching this file from peers — concurrent
-        # writes between urlretrieve and libtorrent corrupted the file in
-        # practice. The file stays in `_http_served` so the daemon's
-        # priority-based filters still treat it as user-selected.
-        # Hold the per-torrent lock around the read-modify-write of priorities;
-        # other code paths (torrent_client.download_file,
-        # torrent_client.get_sequential_bytes, the heartbeat failover) all
-        # mutate the same handle under this lock.
-        if using_http and h is not None:
-            with self.torrent_client.locks.lock(magnet_hash):
-                self._http_served.setdefault(magnet_hash, set()).add(filename)
-                i, _ = torrent.get_index_and_file_from_files(h, filename)
-                if i is not None:
-                    priorities = list(h.file_priorities())
-                    priorities[i] = 0
-                    torrent.prioritize_files(h, priorities)
+        # Hand the debrid URL to libtorrent as a web seed (BEP19) instead of
+        # running a parallel HTTP download. libtorrent stays the sole writer,
+        # hash-verifies every piece, and falls back to peers on its own — so
+        # there's no urlretrieve/libtorrent write race, no priority-0 dance, and
+        # no manual failover. Both single- and multi-file torrents go through the
+        # local reverse-proxy shim: it maps each in-torrent file path back to its
+        # debrid URL and streams the bytes via tinyproxy (so the download takes
+        # the same egress/IP as the debrid API calls). The shim's directory-form
+        # base URL works for single-file torrents too — libtorrent just appends
+        # the lone file name.
+        if h is not None and filename not in self._web_seeded.get(magnet_hash, set()):
+            cached_url = http_cache.get_cached_url(magnet_hash, filename)
+            if cached_url:
+                web_seed_proxy.register(magnet_hash, filename, cached_url)
+                self.torrent_client.add_web_seed(
+                    magnet_hash, web_seed_proxy.base_url(magnet_hash)
+                )
+                self._web_seeded.setdefault(magnet_hash, set()).add(filename)
 
         if download_subtitles:
             for subtitle_filename in _subtitle_filenames(
@@ -325,7 +321,10 @@ class RapidBayDaemon:
         download_rate = torrent_status.download_rate
         if download_path:
             download_rate += self.http_downloader.download_rates.get(download_path, 0)
-        is_http = filename in self._http_served.get(magnet_hash, set())
+        is_http = (
+            filename in self._http_served.get(magnet_hash, set())
+            or filename in self._web_seeded.get(magnet_hash, set())
+        )
         return {
             'status': FileStatus.DOWNLOADING,
             'progress': download_progress,
@@ -371,6 +370,8 @@ class RapidBayDaemon:
         if all(is_state(filename, FileStatus.READY) for filename in active_filenames):
             self.torrent_client.remove_torrent(magnet_hash, remove_files=True)
             self._http_served.pop(magnet_hash, None)
+            self._web_seeded.pop(magnet_hash, None)
+            web_seed_proxy.unregister(magnet_hash)
             for f in files:
                 filepath = os.path.join(settings.DOWNLOAD_DIR, magnet_hash, f.path)
                 self.subtitle_downloads.pop(filepath, None)
@@ -476,6 +477,8 @@ class RapidBayDaemon:
                         self.subtitle_downloads.pop(filepath, None)
                         self.http_downloader.clear(filepath)
                     self._http_served.pop(magnet_hash, None)
+                    self._web_seeded.pop(magnet_hash, None)
+                    web_seed_proxy.unregister(magnet_hash)
                     self.torrent_client.remove_torrent(magnet_hash, remove_files=True)
                 elif h.has_metadata():
                     with self.torrent_client.locks.lock(magnet_hash):

--- a/app/torrent.py
+++ b/app/torrent.py
@@ -209,6 +209,19 @@ class TorrentClient:
             prioritize_files(h, file_priorities)
             self._write_filelist_to_disk(magnet_link)
 
+    def add_web_seed(self, magnet_hash: str, url: str) -> None:
+        """Attach a GetRight-style (BEP19) web seed to a torrent.
+
+        For single-file torrents libtorrent uses the URL directly as the file
+        source, downloading and hash-verifying pieces from it alongside (or
+        instead of) peers. If the web seed errors or serves mismatching bytes,
+        libtorrent disables it and falls back to peers on its own.
+        """
+        with self.locks.lock(magnet_hash):
+            h = self.torrents.get(magnet_hash)
+            if h is not None:
+                h.add_url_seed(url)
+
     def remove_torrent(self, magnet_hash: str, remove_files: bool = False) -> None:
         try:
             h = self.torrents[magnet_hash]

--- a/app/web_seed_proxy.py
+++ b/app/web_seed_proxy.py
@@ -1,0 +1,162 @@
+import http.server
+import os
+import threading
+from typing import Dict, Optional, Tuple, override
+from urllib.parse import unquote
+
+import http_cache
+import log
+import requests
+from common import normalize_filename
+
+# Localhost TCP endpoint that libtorrent connects to when web-seeding a debrid
+# (Real-Debrid / TorBox) file. libtorrent builds a GetRight (BEP19) URL by
+# appending the in-torrent file path to a base URL, but debrid hands out opaque
+# per-file URLs that can't be addressed that way — so we point the web seed at
+# this shim and map each requested in-torrent path back to its debrid URL.
+#
+# The shim is a *reverse proxy*: it fetches the debrid bytes itself via requests
+# (which honors HTTP_PROXY/HTTPS_PROXY → tinyproxy) and streams them to
+# libtorrent over localhost. So the bulk download leaves the box through the
+# same tinyproxy path — and therefore the same IP — as the debrid API calls,
+# rather than out the VPN. libtorrent stays the sole writer and hash-verifies
+# every piece, falling back to peers on its own if the shim can't serve.
+HOST = "127.0.0.1"
+PORT = int(os.environ.get("WEB_SEED_PROXY_PORT", "18889"))
+_CHUNK = 1 << 16
+_CONNECT_TIMEOUT = 15
+_READ_TIMEOUT = 30
+# Statuses that mean the debrid link is gone/expired and worth re-resolving.
+_STALE_STATUSES = {401, 403, 404, 410}
+
+_lock = threading.Lock()
+# magnet_hash -> { normalized basename -> (filename, debrid url) }
+_registry: Dict[str, Dict[str, Tuple[str, str]]] = {}
+_server: Optional["http.server.ThreadingHTTPServer"] = None
+
+
+def register(magnet_hash: str, filename: str, url: str) -> None:
+    with _lock:
+        _registry.setdefault(magnet_hash, {})[
+            normalize_filename(os.path.basename(filename))
+        ] = (filename, url)
+
+
+def unregister(magnet_hash: str) -> None:
+    with _lock:
+        _registry.pop(magnet_hash, None)
+
+
+def _lookup(magnet_hash: str, request_path: str) -> Tuple[str, str] | None:
+    key = normalize_filename(os.path.basename(unquote(request_path)))
+    with _lock:
+        return _registry.get(magnet_hash, {}).get(key)
+
+
+def _open(url: str, range_header: str | None) -> requests.Response | None:
+    headers = {"Range": range_header} if range_header else {}
+    try:
+        return requests.get(
+            url,
+            headers=headers,
+            stream=True,
+            timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT),
+        )
+    except Exception as e:
+        log.debug(f"web seed proxy: upstream fetch failed: {e}")
+        return None
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _serve(self, write_body: bool) -> None:
+        # path is /{magnet_hash}/{in-torrent file path...}
+        parts = self.path.lstrip("/").split("/", 1)
+        if len(parts) != 2:
+            self._fail(404)
+            return
+        magnet_hash, rest = parts
+        entry = _lookup(magnet_hash, rest)
+        if entry is None:
+            self._fail(404)
+            return
+
+        filename, url = entry
+        range_header = self.headers.get("Range")
+        resp = _open(url, range_header)
+
+        # Link likely expired — re-resolve once and retry.
+        if resp is not None and resp.status_code in _STALE_STATUSES:
+            resp.close()
+            fresh = http_cache.get_cached_url(magnet_hash, filename)
+            if fresh and fresh != url:
+                register(magnet_hash, filename, fresh)
+                resp = _open(fresh, range_header)
+
+        if resp is None:
+            self._fail(502)
+            return
+
+        try:
+            self._relay(resp, write_body)
+        finally:
+            resp.close()
+
+    def _relay(self, resp: requests.Response, write_body: bool) -> None:
+        self.send_response(resp.status_code)
+        content_length = resp.headers.get("Content-Length")
+        for header in ("Content-Range", "Content-Type"):
+            value = resp.headers.get(header)
+            if value:
+                self.send_header(header, value)
+        self.send_header("Accept-Ranges", "bytes")
+        if content_length is not None:
+            self.send_header("Content-Length", content_length)
+        else:
+            # Unknown length — can't keep the connection alive safely.
+            self.send_header("Connection", "close")
+        self.end_headers()
+
+        if not write_body:
+            return
+        try:
+            for chunk in resp.iter_content(_CHUNK):
+                if chunk:
+                    self.wfile.write(chunk)
+        except (BrokenPipeError, ConnectionResetError):
+            # libtorrent closed the connection once it had the bytes it wanted.
+            pass
+
+    def _fail(self, status: int) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        self._serve(write_body=True)
+
+    def do_HEAD(self) -> None:
+        self._serve(write_body=False)
+
+    @override
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def start() -> None:
+    global _server
+    with _lock:
+        if _server is not None:
+            return
+        http.server.ThreadingHTTPServer.allow_reuse_address = True
+        _server = http.server.ThreadingHTTPServer((HOST, PORT), _Handler)
+        threading.Thread(target=_server.serve_forever, daemon=True).start()
+        log.debug(f"web seed proxy listening on {HOST}:{PORT}")
+
+
+def base_url(magnet_hash: str) -> str:
+    """Directory-form GetRight web seed base. libtorrent appends the torrent
+    name and file path, yielding /{magnet_hash}/{name}/{path}."""
+    start()
+    return f"http://{HOST}:{PORT}/{magnet_hash}/"


### PR DESCRIPTION
Hand the Real-Debrid/TorBox URL to libtorrent as a GetRight (BEP19) web seed instead of running a parallel HTTP download. libtorrent stays the sole writer, hash-verifies every piece, and falls back to peers on its own — removing the urlretrieve/libtorrent write race, the priority-0 dance, and the manual failover.

web_seed_proxy.py is a localhost reverse-proxy shim that maps each in-torrent file path back to its opaque debrid URL and streams the bytes via requests (honoring HTTP_PROXY → tinyproxy), so the bulk download takes the same egress/IP as the debrid API calls. Stale links are re-resolved once on 401/403/404/410.