### PR TITLE
Attach each debrid provider as a separate web seed

### DIFF
--- a/app/http_cache/__init__.py
+++ b/app/http_cache/__init__.py
@@ -1,11 +1,40 @@
-from typing import List
+from concurrent.futures import ThreadPoolExecutor
+from typing import List, Tuple
 
 from . import real_debrid, torbox
 
-# TorBox first: Real Debrid DMCA-blocks (HTTP 451) most popular content, so it
-# answers far less often than TorBox and a failed RD lookup just adds latency.
-# RD stays as a fallback for the occasional title TorBox lacks.
+# Both providers are offered to libtorrent as separate web seeds when they each
+# have the file cached, so the download fans out across them in parallel and
+# libtorrent recombines the pieces (it stays the sole writer and hash-verifies
+# every piece). TorBox is listed first only so it wins ties in display order —
+# Real Debrid DMCA-blocks (HTTP 451) most popular content and answers far less
+# often.
 _providers = [torbox, real_debrid]
+_by_name = {p.__name__.rsplit(".", 1)[-1]: p for p in _providers}
+
+
+def get_cached_urls(magnet_hash: str, filename: str) -> List[Tuple[str, str]]:
+    """Resolve the debrid URL from every provider that has the file cached,
+    returning (provider_name, url) pairs. Providers are queried concurrently so
+    adding a second provider doesn't add it to the critical-path latency."""
+    with ThreadPoolExecutor(max_workers=len(_by_name)) as executor:
+        futures = {
+            name: executor.submit(provider.get_cached_url, magnet_hash, filename)
+            for name, provider in _by_name.items()
+        }
+    return [
+        (name, url)
+        for name, future in futures.items()
+        if (url := future.result())
+    ]
+
+
+def get_provider_url(provider_name: str, magnet_hash: str, filename: str) -> str | None:
+    """Re-resolve the URL from a single provider (used to refresh a stale link)."""
+    provider = _by_name.get(provider_name)
+    if provider is None:
+        return None
+    return provider.get_cached_url(magnet_hash, filename)
 
 
 def get_cached_url(magnet_hash: str, filename: str) -> str | None:

--- a/app/rapidbaydaemon.py
+++ b/app/rapidbaydaemon.py
@@ -241,19 +241,23 @@ class RapidBayDaemon:
         # running a parallel HTTP download. libtorrent stays the sole writer,
         # hash-verifies every piece, and falls back to peers on its own — so
         # there's no urlretrieve/libtorrent write race, no priority-0 dance, and
-        # no manual failover. Both single- and multi-file torrents go through the
+        # no manual failover. When more than one debrid provider has the file,
+        # each is attached as its own web seed and libtorrent fans piece requests
+        # out across them in parallel, recombining into the one verified file.
+        # Both single- and multi-file torrents go through the
         # local reverse-proxy shim: it maps each in-torrent file path back to its
         # debrid URL and streams the bytes via tinyproxy (so the download takes
         # the same egress/IP as the debrid API calls). The shim's directory-form
         # base URL works for single-file torrents too — libtorrent just appends
         # the lone file name.
         if h is not None and filename not in self._web_seeded.get(magnet_hash, set()):
-            cached_url = http_cache.get_cached_url(magnet_hash, filename)
-            if cached_url:
-                web_seed_proxy.register(magnet_hash, filename, cached_url)
+            cached_urls = http_cache.get_cached_urls(magnet_hash, filename)
+            for provider, cached_url in cached_urls:
+                web_seed_proxy.register(provider, magnet_hash, filename, cached_url)
                 self.torrent_client.add_web_seed(
-                    magnet_hash, web_seed_proxy.base_url(magnet_hash)
+                    magnet_hash, web_seed_proxy.base_url(provider, magnet_hash)
                 )
+            if cached_urls:
                 self._web_seeded.setdefault(magnet_hash, set()).add(filename)
 
         if download_subtitles:

--- a/app/web_seed_proxy.py
+++ b/app/web_seed_proxy.py
@@ -30,27 +30,32 @@ _READ_TIMEOUT = 30
 _STALE_STATUSES = {401, 403, 404, 410}
 
 _lock = threading.Lock()
-# magnet_hash -> { normalized basename -> (filename, debrid url) }
-_registry: Dict[str, Dict[str, Tuple[str, str]]] = {}
+# (provider, magnet_hash) -> { normalized basename -> (filename, debrid url) }
+# Keyed per provider so Real-Debrid and TorBox can be attached as two separate
+# web seeds for the same torrent and each resolve to its own debrid URL.
+_registry: Dict[Tuple[str, str], Dict[str, Tuple[str, str]]] = {}
 _server: Optional["http.server.ThreadingHTTPServer"] = None
 
 
-def register(magnet_hash: str, filename: str, url: str) -> None:
+def register(provider: str, magnet_hash: str, filename: str, url: str) -> None:
     with _lock:
-        _registry.setdefault(magnet_hash, {})[
+        _registry.setdefault((provider, magnet_hash), {})[
             normalize_filename(os.path.basename(filename))
         ] = (filename, url)
 
 
 def unregister(magnet_hash: str) -> None:
     with _lock:
-        _registry.pop(magnet_hash, None)
+        for key in [k for k in _registry if k[1] == magnet_hash]:
+            _registry.pop(key, None)
 
 
-def _lookup(magnet_hash: str, request_path: str) -> Tuple[str, str] | None:
+def _lookup(
+    provider: str, magnet_hash: str, request_path: str
+) -> Tuple[str, str] | None:
     key = normalize_filename(os.path.basename(unquote(request_path)))
     with _lock:
-        return _registry.get(magnet_hash, {}).get(key)
+        return _registry.get((provider, magnet_hash), {}).get(key)
 
 
 def _open(url: str, range_header: str | None) -> requests.Response | None:
@@ -71,13 +76,13 @@ class _Handler(http.server.BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def _serve(self, write_body: bool) -> None:
-        # path is /{magnet_hash}/{in-torrent file path...}
-        parts = self.path.lstrip("/").split("/", 1)
-        if len(parts) != 2:
+        # path is /{provider}/{magnet_hash}/{in-torrent file path...}
+        parts = self.path.lstrip("/").split("/", 2)
+        if len(parts) != 3:
             self._fail(404)
             return
-        magnet_hash, rest = parts
-        entry = _lookup(magnet_hash, rest)
+        provider, magnet_hash, rest = parts
+        entry = _lookup(provider, magnet_hash, rest)
         if entry is None:
             self._fail(404)
             return
@@ -86,12 +91,12 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         range_header = self.headers.get("Range")
         resp = _open(url, range_header)
 
-        # Link likely expired — re-resolve once and retry.
+        # Link likely expired — re-resolve once (from the same provider) and retry.
         if resp is not None and resp.status_code in _STALE_STATUSES:
             resp.close()
-            fresh = http_cache.get_cached_url(magnet_hash, filename)
+            fresh = http_cache.get_provider_url(provider, magnet_hash, filename)
             if fresh and fresh != url:
-                register(magnet_hash, filename, fresh)
+                register(provider, magnet_hash, filename, fresh)
                 resp = _open(fresh, range_header)
 
         if resp is None:
@@ -155,8 +160,10 @@ def start() -> None:
         log.debug(f"web seed proxy listening on {HOST}:{PORT}")
 
 
-def base_url(magnet_hash: str) -> str:
+def base_url(provider: str, magnet_hash: str) -> str:
     """Directory-form GetRight web seed base. libtorrent appends the torrent
-    name and file path, yielding /{magnet_hash}/{name}/{path}."""
+    name and file path, yielding /{provider}/{magnet_hash}/{name}/{path}. The
+    provider segment makes each debrid backend a distinct web seed URL so
+    libtorrent fans piece requests out across them in parallel."""
     start()
-    return f"http://{HOST}:{PORT}/{magnet_hash}/"
+    return f"http://{HOST}:{PORT}/{provider}/{magnet_hash}/"


### PR DESCRIPTION
Real-Debrid and TorBox now each become a distinct BEP19 web seed for the same torrent when both have the file cached, so libtorrent fans piece requests across them in parallel and recombines into one hash-verified file. Providers are resolved concurrently so the second lookup doesn't add to critical-path latency. The web seed proxy registry/URLs are keyed per provider, and stale-link retries re-resolve from the same provider.