### PR TITLE
Show empty search results instead of loading forever

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -878,6 +878,14 @@
                             }
                         }
                         if (data.done) {
+                            // Stream ended without ever delivering a snapshot
+                            // (no indexer returned anything): settle to an
+                            // empty list so the spinner stops and the empty
+                            // state renders instead of loading forever.
+                            if (self.results === null) {
+                                self.results = data.results || [];
+                                focusFirstResult();
+                            }
                             self.searching = false;
                             self.eventsource = null;
                         }


### PR DESCRIPTION
## Problem

Empty search results spun the loading spinner forever instead of rendering the empty state.

## Root cause

In the streaming search path:

- **Backend** (`app/app.py`): result snapshots (`done:false`) are only emitted *while indexers return batches*. When a search matches nothing, zero snapshots are sent and the only terminating event is `{"results": null, "done": true}`.
- **Frontend** (`app/frontend/app.js`): the SSE callback only assigned `self.results` when `data.results` was truthy. A `null` payload left `self.results` at its initial `null`, and the template renders `<loading-spinner v-if="results === null"/>` — so the spinner never cleared.

This only affected the *truly empty* case; when indexers returned an empty batch the snapshot was `[]` (truthy in JS) and rendered fine, which is why it looked intermittent.

## Fix

On the terminating `done` event, if no results ever arrived, settle `self.results` to an empty array so the empty state renders. Frontend-only change — the non-streaming `/api/search/` fallback already returns a concrete list and was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)