### PR TITLE
Fetch cached filelist from providers concurrently

### DIFF
--- a/app/http_cache/__init__.py
+++ b/app/http_cache/__init__.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import tempfile
@@ -66,10 +67,8 @@ def _write_filelist_to_disk(magnet_hash: str, filelist: List[str]) -> None:
         os.replace(tmp_filename, cache_filename)
     except BaseException:
         # Best-effort cleanup so a failed write doesn't leak the temp file.
-        try:
+        with contextlib.suppress(OSError):
             os.remove(tmp_filename)
-        except OSError:
-            pass
         raise
 
 

--- a/app/http_cache/__init__.py
+++ b/app/http_cache/__init__.py
@@ -1,5 +1,9 @@
-from concurrent.futures import ThreadPoolExecutor
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List, Tuple
+
+import settings
 
 from . import real_debrid, torbox
 
@@ -45,10 +49,34 @@ def get_cached_url(magnet_hash: str, filename: str) -> str | None:
 
     return None
 
-def get_cached_filelist(magnet_hash: str) -> List[str] | None:
-    for provider in _providers:
-        filelist = provider.get_filelist(magnet_hash)
-        if filelist:
-            return filelist
+def _write_filelist_to_disk(magnet_hash: str, filelist: List[str]) -> None:
+    """Cache the filelist so the next request short-circuits before any network
+    call. Written via a temp file + atomic replace so concurrent requests for the
+    same hash can't observe a half-written file."""
+    os.makedirs(settings.FILELIST_DIR, exist_ok=True)
+    cache_filename = os.path.join(settings.FILELIST_DIR, magnet_hash)
+    tmp_filename = f"{cache_filename}.{os.getpid()}.tmp"
+    with open(tmp_filename, "w") as f:
+        json.dump(filelist, f)
+    os.replace(tmp_filename, cache_filename)
 
-    return None
+
+def get_cached_filelist(magnet_hash: str) -> List[str] | None:
+    """Query every provider concurrently and return the first non-empty filelist,
+    so adding a second provider doesn't add it to the critical-path latency. The
+    losing provider's request is left to finish in the background (it has no side
+    effects once we've returned)."""
+    executor = ThreadPoolExecutor(max_workers=len(_providers))
+    try:
+        futures = [
+            executor.submit(provider.get_filelist, magnet_hash)
+            for provider in _providers
+        ]
+        for future in as_completed(futures):
+            filelist = future.result()
+            if filelist:
+                _write_filelist_to_disk(magnet_hash, filelist)
+                return filelist
+        return None
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)

--- a/app/http_cache/__init__.py
+++ b/app/http_cache/__init__.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List, Tuple
 
@@ -55,10 +56,21 @@ def _write_filelist_to_disk(magnet_hash: str, filelist: List[str]) -> None:
     same hash can't observe a half-written file."""
     os.makedirs(settings.FILELIST_DIR, exist_ok=True)
     cache_filename = os.path.join(settings.FILELIST_DIR, magnet_hash)
-    tmp_filename = f"{cache_filename}.{os.getpid()}.tmp"
-    with open(tmp_filename, "w") as f:
-        json.dump(filelist, f)
-    os.replace(tmp_filename, cache_filename)
+    # A unique temp file (in the same dir, so os.replace stays atomic) — a
+    # PID-only name would collide when two threads cache the same hash at once,
+    # letting their interleaved writes publish a half-written file.
+    fd, tmp_filename = tempfile.mkstemp(dir=settings.FILELIST_DIR, prefix=f"{magnet_hash}.")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(filelist, f)
+        os.replace(tmp_filename, cache_filename)
+    except BaseException:
+        # Best-effort cleanup so a failed write doesn't leak the temp file.
+        try:
+            os.remove(tmp_filename)
+        except OSError:
+            pass
+        raise
 
 
 def get_cached_filelist(magnet_hash: str) -> List[str] | None:

--- a/app/http_cache/real_debrid.py
+++ b/app/http_cache/real_debrid.py
@@ -8,11 +8,17 @@ import requests
 
 RD_TOKEN = os.environ.get("RD_TOKEN")
 
+# Bound every provider call so a hung request can't keep a fan-out thread alive
+# indefinitely (get_cached_filelist returns on the first winner and leaves the
+# others running in the background).
+REQUEST_TIMEOUT = 30
+
 
 def _get(path: str) -> Dict[str, Any]:
     response = requests.get(
         f"https://api.real-debrid.com/rest/1.0{path}",
         headers={"authorization": f"Bearer {RD_TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     if not (200 <= response.status_code < 300):
         log.debug(f"Real Debrid GET failed: {path} - Status: {response.status_code}")
@@ -26,6 +32,7 @@ def _post(path: str, data: Dict[str, str]) -> Dict[str, Any] | None:
             f"https://api.real-debrid.com/rest/1.0{path}",
             data,
             headers={"authorization": f"Bearer {RD_TOKEN}"},
+            timeout=REQUEST_TIMEOUT,
         )
         if not (200 <= response.status_code < 300):
             log.debug(f"Real Debrid POST failed: {path} - Status: {response.status_code}")

--- a/app/http_cache/real_debrid.py
+++ b/app/http_cache/real_debrid.py
@@ -1,4 +1,3 @@
-import json
 import os
 from typing import Any, Dict, List
 from urllib.parse import unquote
@@ -6,7 +5,6 @@ from urllib.parse import unquote
 import common
 import log
 import requests
-import settings
 
 RD_TOKEN = os.environ.get("RD_TOKEN")
 
@@ -111,13 +109,6 @@ def get_filelist(magnet_hash: str) -> List[str] | None:
 
         files = torrent_info["files"]
         file_paths: List[str] = [f.get("path", "").lstrip("/") for f in files if isinstance(f, dict) and f.get("path")]
-
-        # Write to cache file only if we got results
-        if file_paths:
-            cache_filename = os.path.join(settings.FILELIST_DIR, magnet_hash)
-            os.makedirs(settings.FILELIST_DIR, exist_ok=True)
-            with open(cache_filename, 'w') as f:
-                json.dump(file_paths, f)
 
         return file_paths
 

--- a/app/http_cache/torbox.py
+++ b/app/http_cache/torbox.py
@@ -10,12 +10,18 @@ TB_TOKEN = os.environ.get("TB_TOKEN")
 
 API_BASE = "https://api.torbox.app/v1/api"
 
+# Bound every provider call so a hung request can't keep a fan-out thread alive
+# indefinitely (get_cached_filelist returns on the first winner and leaves the
+# others running in the background).
+REQUEST_TIMEOUT = 30
+
 
 def _get(path: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
     response = requests.get(
         f"{API_BASE}{path}",
         params=params,
         headers={"authorization": f"Bearer {TB_TOKEN}"},
+        timeout=REQUEST_TIMEOUT,
     )
     if not (200 <= response.status_code < 300):
         log.debug(f"TorBox GET failed: {path} - Status: {response.status_code}")
@@ -29,6 +35,7 @@ def _post(path: str, data: Dict[str, str]) -> Dict[str, Any] | None:
             f"{API_BASE}{path}",
             data,
             headers={"authorization": f"Bearer {TB_TOKEN}"},
+            timeout=REQUEST_TIMEOUT,
         )
         if not (200 <= response.status_code < 300):
             log.debug(f"TorBox POST failed: {path} - Status: {response.status_code}")

--- a/app/http_cache/torbox.py
+++ b/app/http_cache/torbox.py
@@ -1,4 +1,3 @@
-import json
 import os
 from typing import Any, Dict, List, Tuple
 from urllib.parse import unquote
@@ -6,7 +5,6 @@ from urllib.parse import unquote
 import common
 import log
 import requests
-import settings
 
 TB_TOKEN = os.environ.get("TB_TOKEN")
 
@@ -135,13 +133,6 @@ def get_filelist(magnet_hash: str) -> List[str] | None:
             for f in files
             if isinstance(f, dict) and (f.get("name") or f.get("path"))
         ]
-
-        # Write to cache file only if we got results
-        if file_paths:
-            cache_filename = os.path.join(settings.FILELIST_DIR, magnet_hash)
-            os.makedirs(settings.FILELIST_DIR, exist_ok=True)
-            with open(cache_filename, 'w') as f:
-                json.dump(file_paths, f)
 
         return file_paths
 


### PR DESCRIPTION
Query every debrid provider concurrently in get_cached_filelist and return the first non-empty result, so adding a second provider doesn't add it to the critical-path latency (mirroring get_cached_urls).

Centralize the on-disk caching in http_cache via a shared _write_filelist_to_disk helper that writes through a temp file + atomic os.replace, so concurrent requests for the same hash can't observe a half-written file. This removes the duplicated cache-writing logic (and now-unused json/settings imports) from the real_debrid and torbox providers.