### PR TITLE
Remove redundant in-table spinner while streaming search results

### DIFF
--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -774,7 +774,7 @@
     Vue.component("search-results-screen", {
         mixins: [rbmixin],
         data: function () {
-            return { results: null, searchterm: "", searching: false };
+            return { results: null, searchterm: "" };
         },
         methods: {
             back: function () {
@@ -859,14 +859,12 @@
                 var fallbackSearch = function () {
                     get("/api/search/" + self.searchterm, function (data) {
                         self.results = data.results;
-                        self.searching = false;
                         focusFirstResult();
                     });
                 };
                 // Stream results over SSE: render a re-ranked snapshot as
                 // each indexer responds instead of waiting for the slowest.
                 var focused = false;
-                this.searching = true;
                 this.eventsource = subscribe(
                     "/api/search_events/" + self.searchterm,
                     function (data) {
@@ -886,7 +884,6 @@
                                 self.results = data.results || [];
                                 focusFirstResult();
                             }
-                            self.searching = false;
                             self.eventsource = null;
                         }
                     },
@@ -894,8 +891,6 @@
                         self.eventsource = null;
                         if (self.results === null) {
                             fallbackSearch();
-                        } else {
-                            self.searching = false;
                         }
                     }
                 );

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -119,9 +119,6 @@
                               </tr>
                           </tbody>
                       </table>
-                      <div v-if="searching" class="search-progress">
-                          <div class="search-progress-spinner"></div>
-                      </div>
                   </div>
               </div>
             </div>

--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -148,21 +148,6 @@ body {
     animation: rotate 5s linear infinite;
 }
 
-.search-progress {
-    display: flex;
-    justify-content: center;
-    padding: 10px 0 20px;
-}
-
-.search-progress-spinner {
-    width: 22px;
-    height: 22px;
-    border: 3px solid #fff;
-    border-top: 3px solid #ccc;
-    border-radius: 50%;
-    animation: rotate 1.5s linear infinite;
-}
-
 @keyframes rotate {
     100% {
         transform: rotate(360deg);


### PR DESCRIPTION
## What

Removes the secondary `search-progress` spinner that rendered below the results table while search results were still streaming in.

## Why

The full-screen `loading-spinner` already covers the state before the first result arrives, and each streamed snapshot re-renders the table in place as indexers respond. The extra in-table spinner therefore added visual noise without conveying anything new.

## Changes

- `index.html` — drop the `search-progress` spinner markup
- `style.css` — drop the now-unused `.search-progress` / `.search-progress-spinner` rules (shared `@keyframes rotate` kept — still used elsewhere)
- `app.js` — remove the now-dead `searching` component state and its assignments

Follow-up to #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)