### PR TITLE
Negative-cache uncached debrid filelist lookups

### DIFF
--- a/app/http_cache/__init__.py
+++ b/app/http_cache/__init__.py
@@ -2,8 +2,10 @@ import contextlib
 import json
 import os
 import tempfile
+import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import settings
 
@@ -17,6 +19,19 @@ from . import real_debrid, torbox
 # often.
 _providers = [torbox, real_debrid]
 _by_name = {p.__name__.rsplit(".", 1)[-1]: p for p in _providers}
+
+# Negative cache for get_cached_filelist: hashes that recently resolved to "no
+# cached filelist on any provider". A browse view polls get_cached_filelist on a
+# loop, and every miss otherwise re-queries each provider — where each
+# provider's get_filelist re-adds the magnet to that account as a side effect
+# (Real-Debrid addMagnet, TorBox createtorrent — the latter also queues a
+# server-side download). Remembering misses for a short TTL keeps a polling
+# browser from hammering the debrid APIs and re-adding uncached magnets every
+# tick. Successful lookups need no entry here: they get written to the on-disk
+# filelist cache, which short-circuits the whole call earlier up the stack.
+_NEGATIVE_TTL = 60.0  # seconds
+_negative_cache: Dict[str, float] = {}
+_negative_lock = threading.Lock()
 
 
 def get_cached_urls(magnet_hash: str, filename: str) -> List[Tuple[str, str]]:
@@ -77,6 +92,14 @@ def get_cached_filelist(magnet_hash: str) -> List[str] | None:
     so adding a second provider doesn't add it to the critical-path latency. The
     losing provider's request is left to finish in the background (it has no side
     effects once we've returned)."""
+    now = time.monotonic()
+    with _negative_lock:
+        # Prune expired misses so the cache can't grow unbounded across hashes.
+        for h in [h for h, ts in _negative_cache.items() if now - ts >= _NEGATIVE_TTL]:
+            del _negative_cache[h]
+        if magnet_hash in _negative_cache:
+            return None
+
     executor = ThreadPoolExecutor(max_workers=len(_providers))
     try:
         futures = [
@@ -88,6 +111,10 @@ def get_cached_filelist(magnet_hash: str) -> List[str] | None:
             if filelist:
                 _write_filelist_to_disk(magnet_hash, filelist)
                 return filelist
+        # No provider had it cached — remember the miss so a polling caller
+        # doesn't re-add the magnet on every tick until it's actually cached.
+        with _negative_lock:
+            _negative_cache[magnet_hash] = now
         return None
     finally:
         executor.shutdown(wait=False, cancel_futures=True)

--- a/app/http_cache/__init__.py
+++ b/app/http_cache/__init__.py
@@ -106,15 +106,26 @@ def get_cached_filelist(magnet_hash: str) -> List[str] | None:
             executor.submit(provider.get_filelist, magnet_hash)
             for provider in _providers
         ]
+        had_error = False
         for future in as_completed(futures):
-            filelist = future.result()
+            try:
+                filelist = future.result()
+            except Exception:
+                # A provider errored (network/API failure) rather than reporting
+                # a definitive "not cached". Don't count this toward a miss —
+                # let the next poll retry instead of freezing the outage in.
+                had_error = True
+                continue
             if filelist:
                 _write_filelist_to_disk(magnet_hash, filelist)
                 return filelist
-        # No provider had it cached — remember the miss so a polling caller
-        # doesn't re-add the magnet on every tick until it's actually cached.
-        with _negative_lock:
-            _negative_cache[magnet_hash] = now
+        # Only remember a miss when every provider answered without erroring, so
+        # a transient outage isn't cached as "not cached" for the whole TTL.
+        # Timestamp the miss now (not at entry) so the full TTL runs from the
+        # confirmed miss rather than being eaten by slow provider calls.
+        if not had_error:
+            with _negative_lock:
+                _negative_cache[magnet_hash] = time.monotonic()
         return None
     finally:
         executor.shutdown(wait=False, cancel_futures=True)

--- a/app/http_cache/real_debrid.py
+++ b/app/http_cache/real_debrid.py
@@ -120,5 +120,8 @@ def get_filelist(magnet_hash: str) -> List[str] | None:
         return file_paths
 
     except Exception as e:
+        # Surface the error rather than masking it as an empty result, so
+        # get_cached_filelist can tell a transient failure apart from a genuine
+        # "not cached" and avoid poisoning its negative cache with the former.
         log.debug(f"Real Debrid filelist error for {magnet_hash}: {str(e)}")
-        return None
+        raise

--- a/app/http_cache/torbox.py
+++ b/app/http_cache/torbox.py
@@ -144,5 +144,8 @@ def get_filelist(magnet_hash: str) -> List[str] | None:
         return file_paths
 
     except Exception as e:
+        # Surface the error rather than masking it as an empty result, so
+        # get_cached_filelist can tell a transient failure apart from a genuine
+        # "not cached" and avoid poisoning its negative cache with the former.
         log.debug(f"TorBox filelist error for {magnet_hash}: {str(e)}")
-        return None
+        raise


### PR DESCRIPTION
Browsing a magnet polls get_cached_filelist on a loop (the file-list view keeps requesting until a list is available). On a miss it re-queries every provider, and each provider's get_filelist re-adds the magnet to that account as a side effect: Real-Debrid addMagnet, TorBox createtorrent — the latter also queues a server-side download. So an open browse tab on an uncached (or not-yet-cached) magnet hammered both debrid APIs and repeatedly re-added the magnet, roughly once per poll, indefinitely.

Remember "no provider had it cached" results for a short TTL so a polling caller stops re-querying (and re-adding) until the magnet is actually cached. Successful lookups already short-circuit via the on-disk filelist cache, so they need no entry here. Expired entries are pruned on access to keep the cache bounded.