### PR TITLE
Self-heal listen + DHT sockets after network blips

### DIFF
--- a/app/torrent.py
+++ b/app/torrent.py
@@ -146,6 +146,9 @@ class TorrentClient:
         self.torrents_dir: str | None = torrents_dir
         # Optional hook fired when the filelist is written (metadata resolved)
         self.on_state_change: Callable[[], None] | None = None
+        # Network self-healing state (see _watchdog_network).
+        self._last_watchdog: float = time.monotonic()
+        self._dht_dead_streak: int = 0
 
     def process_alerts(self) -> None:
         """Process session alerts for better torrent monitoring"""
@@ -167,6 +170,47 @@ class TorrentClient:
                 print("DHT bootstrap completed")
             elif isinstance(alert, libtorrent.listen_succeeded_alert):
                 print(f"Listening on {alert.address}:{alert.port}")
+            elif isinstance(alert, libtorrent.listen_failed_alert):
+                # Bind failure — the watchdog will reopen sockets on its tick.
+                print(f"Listen failed on {alert.address}:{alert.port}: {alert.error}")
+        self._watchdog_network()
+
+    # A long-lived session can silently lose its listen + DHT sockets after a
+    # host network blip (VPN reconnect, interface bounce). Metadata fetches then
+    # time out forever because no peers are reachable — even though a fresh
+    # session on the same box works fine. libtorrent won't rebind on its own, so
+    # we watch DHT liveness and call reopen_network_sockets() when it flatlines.
+    _WATCHDOG_INTERVAL = 60.0  # seconds between health checks
+    _DHT_DEAD_CHECKS = 2  # consecutive dead checks (~2 min) before reopening
+
+    def _watchdog_network(self) -> None:
+        now = time.monotonic()
+        if now - self._last_watchdog < self._WATCHDOG_INTERVAL:
+            return
+        self._last_watchdog = now
+        try:
+            dht_nodes = self.session.status().dht_nodes
+            listening = self.session.is_listening()
+        except Exception:
+            return
+        if dht_nodes > 0 and listening:
+            self._dht_dead_streak = 0
+            return
+        self._dht_dead_streak += 1
+        if self._dht_dead_streak < self._DHT_DEAD_CHECKS:
+            return
+        # Sockets look dead — rebind listen + DHT in place. Existing torrent
+        # handles survive; they just regain working sockets.
+        print(
+            f"web torrent: network down (dht_nodes={dht_nodes}, "
+            f"listening={listening}) — reopening sockets",
+            flush=True,
+        )
+        with contextlib.suppress(Exception):
+            self.session.reopen_network_sockets()
+        with contextlib.suppress(Exception):
+            self.session.start_dht()
+        self._dht_dead_streak = 0
 
     def fetch_filelist_from_link(self, magnet_link: str) -> None:
         if self.filelist_dir is None:

--- a/app/torrent.py
+++ b/app/torrent.py
@@ -149,6 +149,7 @@ class TorrentClient:
         # Network self-healing state (see _watchdog_network).
         self._last_watchdog: float = time.monotonic()
         self._dht_dead_streak: int = 0
+        self._was_healthy: bool = False
 
     def process_alerts(self) -> None:
         """Process session alerts for better torrent monitoring"""
@@ -180,6 +181,12 @@ class TorrentClient:
     # time out forever because no peers are reachable — even though a fresh
     # session on the same box works fine. libtorrent won't rebind on its own, so
     # we watch DHT liveness and call reopen_network_sockets() when it flatlines.
+    #
+    # We only act on a *regression*: the session must have been healthy at least
+    # once before we treat a dead check as a blip to recover from. Otherwise an
+    # environment where DHT never bootstraps (UDP filtered, but trackers/web
+    # seeds work fine) would thrash the listen socket every couple of minutes
+    # forever, disrupting working transfers and spamming logs.
     _WATCHDOG_INTERVAL = 60.0  # seconds between health checks
     _DHT_DEAD_CHECKS = 2  # consecutive dead checks (~2 min) before reopening
 
@@ -194,7 +201,11 @@ class TorrentClient:
         except Exception:
             return
         if dht_nodes > 0 and listening:
+            self._was_healthy = True
             self._dht_dead_streak = 0
+            return
+        # Never been healthy → nothing to recover to; leave it alone.
+        if not self._was_healthy:
             return
         self._dht_dead_streak += 1
         if self._dht_dead_streak < self._DHT_DEAD_CHECKS:
@@ -206,10 +217,14 @@ class TorrentClient:
             f"listening={listening}) — reopening sockets",
             flush=True,
         )
-        with contextlib.suppress(Exception):
+        try:
             self.session.reopen_network_sockets()
-        with contextlib.suppress(Exception):
+        except Exception as e:
+            print(f"web torrent: reopen_network_sockets failed: {e}", flush=True)
+        try:
             self.session.start_dht()
+        except Exception as e:
+            print(f"web torrent: start_dht failed: {e}", flush=True)
         self._dht_dead_streak = 0
 
     def fetch_filelist_from_link(self, magnet_link: str) -> None:


### PR DESCRIPTION
A long-lived libtorrent session can silently lose its listen and DHT sockets after a host network blip (VPN reconnect, interface bounce), leaving metadata fetches to time out forever. Add a network watchdog that reopens sockets when DHT liveness flatlines.