### PR TITLE
Fix arbitrary file read, command injection and SSRF

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2,11 +2,13 @@ import asyncio
 import contextlib
 import datetime
 import fcntl
+import ipaddress
 import json
 import os
 import random
 import re
 import shlex
+import socket
 import string
 import subprocess
 import urllib.parse
@@ -17,6 +19,7 @@ from typing import Annotated, Any, AsyncIterator, Dict, List
 import diskcache
 import http_cache
 import jackett
+import log
 import prowlarr
 import PTN
 import requests
@@ -335,9 +338,23 @@ def authorize(
     raise HTTPException(status_code=404)
 
 
+def _resolve_within(directory: str, path: str) -> str | None:
+    """Resolve `path` relative to `directory`, returning None if it escapes it.
+
+    `os.path.join` silently discards `directory` when `path` is absolute, and
+    uvicorn percent-decodes the request path before routing, so `%2Fetc%2Fpasswd`
+    arrives here as a plain absolute path. Both that and `..` traversal have to
+    be rejected on the resolved path."""
+    root = os.path.realpath(directory)
+    filepath = os.path.realpath(os.path.join(root, path))
+    if filepath != root and not filepath.startswith(root + os.sep):
+        return None
+    return filepath
+
+
 def _send_from_directory(directory: str, filename: str, last_modified: datetime.datetime | None = None) -> FileResponse:
-    filepath = os.path.join(directory, filename)
-    if not os.path.isfile(filepath):
+    filepath = _resolve_within(directory, filename)
+    if not filepath or not os.path.isfile(filepath):
         raise HTTPException(status_code=404, detail="File not found")
     headers: Dict[str, str] = {}
     if last_modified:
@@ -616,23 +633,77 @@ def _get_cached_magnet(torrent_url: str) -> str | None:
     return cache.get(torrent_url)
 
 
+MAX_TORRENT_FILE_BYTES: int = 10 * 1024 * 1024
+
+
+def _indexer_hostnames() -> set[str]:
+    hostnames: set[str] = set()
+    for host in (settings.JACKETT_HOST, settings.PROWLARR_HOST):
+        if not host:
+            continue
+        hostname = urllib.parse.urlparse(host).hostname
+        if hostname:
+            hostnames.add(hostname.lower())
+    return hostnames
+
+
+def _is_fetchable_url(url: str) -> bool:
+    """SSRF guard for operator-supplied torrent URLs.
+
+    Only http(s), and nothing that resolves onto the local network - cloud
+    metadata at 169.254.169.254, internal admin panels, loopback. The
+    configured indexers are exempt: Jackett/Prowlarr normally run on a private
+    docker network, and their download links are the main legitimate input."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    hostname: str | None = parsed.hostname
+    if not hostname:
+        return False
+    if hostname.lower() in _indexer_hostnames():
+        return True
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError, ValueError):
+        return False
+    if not addrinfo:
+        return False
+    for info in addrinfo:
+        address = ipaddress.ip_address(info[4][0])
+        if not address.is_global or address.is_multicast:
+            return False
+    return True
+
+
 def _torrent_url_to_magnet(torrent_url: str) -> str | None:
     # Check cache first
     cached = _get_cached_magnet(torrent_url)
     if cached:
         return cached
 
+    if not _is_fetchable_url(torrent_url):
+        log.debug(f"Refusing to fetch torrent url: {torrent_url}")
+        return None
+
     filepath: str = os.path.join(settings.DATA_DIR, ''.join(random.choices(string.ascii_uppercase + string.digits, k=10)) + ".torrent")
     magnet_link: str | None = None
     try:
-        r: requests.Response = requests.get(torrent_url, allow_redirects=False, timeout=30)
-        if r.status_code in (301, 302, 303, 307, 308):
-            location: str | None = r.headers.get("Location")
-            if location and location.startswith("magnet"):
-                _save_torrent_url_to_cache(torrent_url, location)
-                return location
+        with requests.get(torrent_url, allow_redirects=False, timeout=30, stream=True) as r:
+            if r.status_code in (301, 302, 303, 307, 308):
+                location: str | None = r.headers.get("Location")
+                if location and location.startswith("magnet"):
+                    _save_torrent_url_to_cache(torrent_url, location)
+                    return location
+            # Bounded read - the response body is unvalidated remote input that
+            # gets handed to the bencode/libtorrent parsers.
+            content = bytearray()
+            for chunk in r.iter_content(64 * 1024):
+                content += chunk
+                if len(content) > MAX_TORRENT_FILE_BYTES:
+                    log.debug(f"Torrent url response too large: {torrent_url}")
+                    return None
         with open(filepath, 'wb') as f:
-            f.write(r.content)
+            f.write(content)
         daemon.save_torrent_file(filepath)
         magnet_link = torrent.make_magnet_from_torrent_file(filepath)
         if magnet_link:
@@ -874,11 +945,10 @@ def kodi_repo(request: Request, path: str = "") -> Response:
 
 @app.get("/play/{magnet_hash}/{filename:path}")
 def play(magnet_hash: str, filename: str, _: None = Depends(authorize)) -> Response:
-    directory = os.path.realpath(os.path.join(settings.OUTPUT_DIR, magnet_hash))
-    filepath = os.path.realpath(os.path.join(directory, filename))
-    if not filepath.startswith(directory + os.sep):
-        raise HTTPException(status_code=404, detail="File not found")
-    if not os.path.isfile(filepath):
+    # Anchored on OUTPUT_DIR itself - anchoring on OUTPUT_DIR/<magnet_hash>
+    # lets a traversing magnet_hash move the root of the containment check.
+    filepath = _resolve_within(settings.OUTPUT_DIR, os.path.join(magnet_hash, filename))
+    if not filepath or not os.path.isfile(filepath):
         raise HTTPException(status_code=404, detail="File not found")
     response = FileResponse(filepath)
     response.headers["Access-Control-Allow-Origin"] = "*"
@@ -891,8 +961,8 @@ def frontend(path: str, password: str | None = Cookie(default=None)) -> Response
     if path == "":
         path = "index.html"
     if not path.startswith("index.html"):
-        filepath = os.path.join(settings.FRONTEND_DIR, path)
-        if os.path.isfile(filepath):
+        filepath = _resolve_within(settings.FRONTEND_DIR, path)
+        if filepath and os.path.isfile(filepath):
             return FileResponse(filepath)
     if not settings.PASSWORD or password == settings.PASSWORD:
         return _send_from_directory(settings.FRONTEND_DIR, "index.html", last_modified=datetime.datetime.now())

--- a/app/app.py
+++ b/app/app.py
@@ -14,7 +14,7 @@ import subprocess
 import urllib.parse
 from collections.abc import Generator
 from contextlib import asynccontextmanager
-from typing import Annotated, Any, AsyncIterator, Dict, List
+from typing import Annotated, Any, AsyncIterator, Dict, List, override
 
 import diskcache
 import http_cache
@@ -23,6 +23,7 @@ import log
 import prowlarr
 import PTN
 import requests
+import requests.adapters
 import settings
 import torrent
 from common import path_hierarchy
@@ -636,43 +637,118 @@ def _get_cached_magnet(torrent_url: str) -> str | None:
 MAX_TORRENT_FILE_BYTES: int = 10 * 1024 * 1024
 
 
-def _indexer_hostnames() -> set[str]:
-    hostnames: set[str] = set()
+def _origin(parsed: urllib.parse.ParseResult) -> tuple[str, str, int] | None:
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    default_port: int = 443 if parsed.scheme == "https" else 80
+    return (parsed.scheme, parsed.hostname.lower(), parsed.port or default_port)
+
+
+def _indexer_origins() -> set[tuple[str, str, int]]:
+    """Scheme/host/port of the configured indexers.
+
+    Matching the whole origin rather than just the hostname keeps the exemption
+    to the indexer itself - another service on the same box, on a different
+    port, is not covered by it."""
+    origins: set[tuple[str, str, int]] = set()
     for host in (settings.JACKETT_HOST, settings.PROWLARR_HOST):
         if not host:
             continue
-        hostname = urllib.parse.urlparse(host).hostname
-        if hostname:
-            hostnames.add(hostname.lower())
-    return hostnames
+        origin = _origin(urllib.parse.urlparse(host))
+        if origin:
+            origins.add(origin)
+    return origins
 
 
-def _is_fetchable_url(url: str) -> bool:
-    """SSRF guard for operator-supplied torrent URLs.
+def _fetch_target_ip(torrent_url: str) -> str | None:
+    """SSRF guard for torrent URLs: returns the IP to connect to, or None when
+    the URL must not be fetched at all.
 
-    Only http(s), and nothing that resolves onto the local network - cloud
-    metadata at 169.254.169.254, internal admin panels, loopback. The
-    configured indexers are exempt: Jackett/Prowlarr normally run on a private
-    docker network, and their download links are the main legitimate input."""
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        return False
-    hostname: str | None = parsed.hostname
-    if not hostname:
-        return False
-    if hostname.lower() in _indexer_hostnames():
-        return True
+    Only http(s), and nothing on the local network - cloud metadata at
+    169.254.169.254, internal admin panels, loopback. Jackett/Prowlarr normally
+    run on a private docker network and their download links are the main
+    legitimate input, so the configured indexer origins skip that check.
+
+    The address is returned so the caller can pin the connection to it. Letting
+    requests resolve the hostname a second time would leave a window in which
+    DNS can rebind to an internal address after this check has passed."""
+    parsed = urllib.parse.urlparse(torrent_url)
+    origin = _origin(parsed)
+    if not origin:
+        return None
     try:
-        addrinfo = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
-    except (socket.gaierror, UnicodeError, ValueError):
-        return False
-    if not addrinfo:
-        return False
-    for info in addrinfo:
-        address = ipaddress.ip_address(info[4][0])
-        if not address.is_global or address.is_multicast:
-            return False
-    return True
+        addrinfo = socket.getaddrinfo(parsed.hostname, origin[2], proto=socket.IPPROTO_TCP)
+    except (OSError, UnicodeError, ValueError):
+        return None
+    addresses = [ipaddress.ip_address(info[4][0]) for info in addrinfo]
+    if not addresses:
+        return None
+    if origin not in _indexer_origins():
+        for address in addresses:
+            if not address.is_global or address.is_multicast:
+                return None
+    return str(addresses[0])
+
+
+class _PinnedIPAdapter(requests.adapters.HTTPAdapter):
+    """Connects to an already-validated IP instead of re-resolving the host.
+
+    The request URL is left untouched, so the Host header, SNI and certificate
+    validation all still use the real hostname - only the address the socket
+    connects to is pinned.
+
+    get_connection is the hook requests 2.31 (the pinned version) routes every
+    send() through. requests 2.32 moved it to get_connection_with_tls_context,
+    so on a newer requests the pinning would quietly stop applying and the SSRF
+    guard would fall back to its pre-pinning strength - still blocking direct
+    internal targets, but with the DNS-rebinding window reopened.
+    test_connection_is_pinned_and_keeps_the_real_host_header fails loudly if
+    that happens, so a dependency bump cannot land silently."""
+
+    def __init__(self, ip: str) -> None:
+        self._ip: str = ip
+        super().__init__(max_retries=0)
+
+    @override
+    def get_connection(self, url: Any, proxies: Any = None) -> Any:
+        # The base signature accepts str | bytes.
+        url_str: str = url.decode("utf-8") if isinstance(url, bytes) else str(url)
+        if proxies and requests.utils.select_proxy(url_str, proxies):
+            # The proxy is the egress point and resolves the name itself;
+            # pinning here would only bypass it.
+            return super().get_connection(url, proxies)
+        parsed: urllib.parse.ParseResult = urllib.parse.urlparse(url_str)
+        # server_hostname drives both SNI and the certificate hostname match.
+        pool_kwargs: Dict[str, Any] = (
+            {"server_hostname": parsed.hostname} if parsed.scheme == "https" else {}
+        )
+        return self.poolmanager.connection_from_host(
+            self._ip, port=parsed.port, scheme=parsed.scheme, pool_kwargs=pool_kwargs
+        )
+
+
+def _host_header(parsed: urllib.parse.ParseResult) -> str:
+    hostname: str = parsed.hostname or ""
+    if ":" in hostname:  # IPv6 literal
+        hostname = f"[{hostname}]"
+    return f"{hostname}:{parsed.port}" if parsed.port else hostname
+
+
+def _get_pinned(url: str, ip: str, **kwargs: Any) -> requests.Response:
+    """GET `url` with the connection pinned to `ip`."""
+    # urllib3 derives the Host header from the address it connected to, which
+    # is the pinned IP - set it explicitly so name-based virtual hosts still
+    # see the real hostname.
+    headers: Dict[str, str] = {"Host": _host_header(urllib.parse.urlparse(url))}
+    headers.update(kwargs.pop("headers", None) or {})
+    session = requests.Session()
+    session.mount("http://", _PinnedIPAdapter(ip))
+    session.mount("https://", _PinnedIPAdapter(ip))
+    try:
+        return session.get(url, headers=headers, **kwargs)
+    except BaseException:
+        session.close()
+        raise
 
 
 def _torrent_url_to_magnet(torrent_url: str) -> str | None:
@@ -681,14 +757,15 @@ def _torrent_url_to_magnet(torrent_url: str) -> str | None:
     if cached:
         return cached
 
-    if not _is_fetchable_url(torrent_url):
+    target_ip = _fetch_target_ip(torrent_url)
+    if not target_ip:
         log.debug(f"Refusing to fetch torrent url: {torrent_url}")
         return None
 
     filepath: str = os.path.join(settings.DATA_DIR, ''.join(random.choices(string.ascii_uppercase + string.digits, k=10)) + ".torrent")
     magnet_link: str | None = None
     try:
-        with requests.get(torrent_url, allow_redirects=False, timeout=30, stream=True) as r:
+        with _get_pinned(torrent_url, target_ip, allow_redirects=False, timeout=30, stream=True) as r:
             if r.status_code in (301, 302, 303, 307, 308):
                 location: str | None = r.headers.get("Location")
                 if location and location.startswith("magnet"):

--- a/app/app.py
+++ b/app/app.py
@@ -14,7 +14,7 @@ import subprocess
 import urllib.parse
 from collections.abc import Generator
 from contextlib import asynccontextmanager
-from typing import Annotated, Any, AsyncIterator, Dict, List, override
+from typing import Annotated, Any, AsyncIterator, Dict, List, cast, override
 
 import diskcache
 import http_cache
@@ -24,6 +24,7 @@ import prowlarr
 import PTN
 import requests
 import requests.adapters
+import requests.utils
 import settings
 import torrent
 from common import path_hierarchy
@@ -716,7 +717,8 @@ class _PinnedIPAdapter(requests.adapters.HTTPAdapter):
         if proxies and requests.utils.select_proxy(url_str, proxies):
             # The proxy is the egress point and resolves the name itself;
             # pinning here would only bypass it.
-            return super().get_connection(url, proxies)
+            # types-requests leaves get_connection unannotated, hence the cast.
+            return cast(Any, super().get_connection(url, proxies))
         parsed: urllib.parse.ParseResult = urllib.parse.urlparse(url_str)
         # server_hostname drives both SNI and the certificate hostname match.
         pool_kwargs: Dict[str, Any] = (

--- a/app/subtitles.py
+++ b/app/subtitles.py
@@ -1,4 +1,6 @@
+import contextlib
 import os
+import subprocess
 import time
 from typing import Any, Dict, Generator, List
 from xmlrpc.client import ProtocolError
@@ -95,8 +97,17 @@ def download_all_subtitles(filepath: str, skip: List[str] | None = None) -> None
     for sub_filename in sub_filenames:
         tmp_path = os.path.join(dirname, "fixed_" + sub_filename)
         output_path = os.path.join(dirname, sub_filename)
-        os.system(f"timeout 5m alass '{filepath}' '{output_path}' '{tmp_path}'")
-        os.system(f"mv '{tmp_path}' '{output_path}'")
+        # Argument-list form: these paths come from torrent file names and
+        # subtitle file names, both attacker-controlled.
+        with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+            subprocess.run(
+                ["alass", filepath, output_path, tmp_path],
+                timeout=300,
+                check=False,
+            )
+        # alass leaves no output file when it fails; keep the unsynced original.
+        if os.path.isfile(tmp_path):
+            os.replace(tmp_path, output_path)
 
 
 def get_subtitle_language(subtitle_filename: str) -> str | None:

--- a/app/video_conversion.py
+++ b/app/video_conversion.py
@@ -2,6 +2,7 @@ import contextlib
 import datetime
 import os
 import re
+import shlex
 import subprocess
 import time
 from subprocess import Popen, TimeoutExpired
@@ -42,16 +43,14 @@ def _extract_subtitles_as_vtt(filepath: str) -> Any:
     basename: str = os.path.basename(filepath)
     filename_without_extension: str = os.path.splitext(basename)[0]
     sub_tracks: List[Tuple[int, str]] = get_sub_tracks(filepath)
-    return Popen(
-        f'ffmpeg -nostdin -v quiet -i "{filepath}" '
-        + " ".join(
-            [
-                f'-map 0:{i} "{output_dir}/{filename_without_extension}.{i}_{lang}.vtt"'
-                for (i, lang) in sub_tracks
-            ]
-        ),
-        shell=True,
-    )
+    args: List[str] = ["ffmpeg", "-nostdin", "-v", "quiet", "-i", filepath]
+    for (i, lang) in sub_tracks:
+        args += [
+            "-map",
+            f"0:{i}",
+            os.path.join(output_dir, f"{filename_without_extension}.{i}_{lang}.vtt"),
+        ]
+    return Popen(args)
 
 
 def _ffprobe_stream_codecs(filepath: str, stream_type: str) -> List[str] | None:
@@ -89,10 +88,15 @@ def _video_codec_passthrough(codec: str) -> bool:
     return any(s in codec for s in ("h264", "h265", "avc", "hevc", "av1"))
 
 
+def incomplete_filepath(output_filepath: str) -> str:
+    """Path ffmpeg writes to while a conversion is still running."""
+    output_extension: str = os.path.splitext(output_filepath)[1]
+    return f"{output_filepath}{settings.INCOMPLETE_POSTFIX}{output_extension}"
+
+
 def _convert_file_to_mp4(input_filepath: str, output_filepath: str, subtitle_filepaths: List[Tuple[str | None, str]] | None = None) -> Any:
     if subtitle_filepaths is None:
         subtitle_filepaths = []
-    output_extension: str = os.path.splitext(output_filepath)[1]
     media_info: Any = MediaInfo.parse(input_filepath)
     # Codec detection via ffprobe — MediaInfo's `format` strings vary across
     # containers (e.g. "AAC LC", "MPEG-4 Audio") and miss codecs entirely on
@@ -140,40 +144,49 @@ def _convert_file_to_mp4(input_filepath: str, output_filepath: str, subtitle_fil
             duration_int = None
         with open(f"{output_filepath}{settings.LOG_POSTFIX}", "w") as f:
             f.write(f"{duration_int}\r")
-    return Popen(
-        " ".join(
-            [
-                "ffmpeg -nostdin -threads 0",
-                f'-i "{input_filepath}"',
-                " ".join([f'-f srt -i "{fn}"' for (_, fn) in subtitle_filepaths]),
-                "-map 0:v?",
-                "-map 0:a?",
-                "-map 0:s?" if n_sub_tracks > 0 else "",
-                f"-acodec aac -aac_coder fast -ab {settings.AAC_BITRATE} -ac {settings.AAC_CHANNELS}"
-                if needs_audio_conversion
-                else "-acodec copy",
-                "-vcodec " + settings.VIDEO_CONVERSION_PARAMS
-                if needs_video_conversion
-                else "-vcodec copy",
-                " ".join([f"-map {i}?" for i in range(1, len(subtitle_filepaths) + 1)]),
-                " ".join(
-                    [
-                        f"-metadata:s:s:{i + n_sub_tracks} language='{subtitle_filepaths[i][0]}'"
-                        for i in range(0, len(subtitle_filepaths))
-                        if subtitle_filepaths[i][0] is not None
-                    ]
-                ),
-                "-c:s mov_text",
-                "-movflags faststart",
-                "-v quiet -stats",
-                "-tag:v hvc1" if is_hevc else "",
-                f'"{output_filepath}{settings.INCOMPLETE_POSTFIX}{output_extension}" 2>> "{output_filepath}{settings.LOG_POSTFIX}"',
-                "&&",
-                f'mv "{output_filepath}{settings.INCOMPLETE_POSTFIX}{output_extension}" "{output_filepath}"',
-            ]
-        ),
-        shell=True,
-    )
+    # Argument-list form, never a shell string: input_filepath and the subtitle
+    # paths derive from file names inside the torrent, which are fully
+    # attacker-controlled and would otherwise be interpreted by the shell.
+    args: List[str] = ["ffmpeg", "-nostdin", "-threads", "0", "-i", input_filepath]
+    for (_, fn) in subtitle_filepaths:
+        args += ["-f", "srt", "-i", fn]
+    args += ["-map", "0:v?", "-map", "0:a?"]
+    if n_sub_tracks > 0:
+        args += ["-map", "0:s?"]
+    if needs_audio_conversion:
+        args += [
+            "-acodec", "aac",
+            "-aac_coder", "fast",
+            "-ab", str(settings.AAC_BITRATE),
+            "-ac", str(settings.AAC_CHANNELS),
+        ]
+    else:
+        args += ["-acodec", "copy"]
+    if needs_video_conversion:
+        # Operator-supplied setting, split the way the shell used to split it.
+        args += ["-vcodec"] + shlex.split(settings.VIDEO_CONVERSION_PARAMS)
+    else:
+        args += ["-vcodec", "copy"]
+    for i in range(1, len(subtitle_filepaths) + 1):
+        args += ["-map", f"{i}?"]
+    for i in range(0, len(subtitle_filepaths)):
+        language = subtitle_filepaths[i][0]
+        if language is not None:
+            args += [f"-metadata:s:s:{i + n_sub_tracks}", f"language={language}"]
+    args += [
+        "-c:s", "mov_text",
+        "-movflags", "faststart",
+        "-v", "quiet",
+        "-stats",
+    ]
+    if is_hevc:
+        args += ["-tag:v", "hvc1"]
+    args += [incomplete_filepath(output_filepath)]
+
+    # ffmpeg's progress stats go to stderr; get_conversion_progress reads them
+    # back out of the log file, which previously came from a `2>>` redirection.
+    with open(f"{output_filepath}{settings.LOG_POSTFIX}", "a") as logfile:
+        return Popen(args, stderr=logfile)
 
 
 def get_conversion_progress(filepath: str) -> float:
@@ -248,6 +261,9 @@ class VideoConverter:
 
             if conversion.returncode != 0:
                 raise Exception(f"Conversion failed for {input_filepath}")
+
+            # Publish atomically, the way the old `&& mv` did.
+            os.replace(incomplete_filepath(output_filepath), output_filepath)
 
             _extract_subtitles_as_vtt(output_filepath).wait()
 

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -1,0 +1,36 @@
+"""Regression tests for the static-file containment check.
+
+uvicorn percent-decodes the request path before routing, so `/%2Fetc%2Fpasswd`
+reaches the catch-all frontend route as the absolute path `/etc/passwd`, and
+`os.path.join` silently drops the FRONTEND_DIR prefix.
+"""
+
+import os
+
+from app.app import _resolve_within
+
+
+def test_relative_paths_resolve(tmp_path):
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "app.js").write_text("x")
+    (tmp_path / "lib" / "a.js").write_text("y")
+
+    assert _resolve_within(str(tmp_path), "app.js") == str(tmp_path / "app.js")
+    assert _resolve_within(str(tmp_path), "lib/a.js") == str(tmp_path / "lib" / "a.js")
+    assert _resolve_within(str(tmp_path), "lib/../app.js") == str(tmp_path / "app.js")
+
+
+def test_absolute_and_traversing_paths_are_rejected(tmp_path):
+    for path in ["/etc/passwd", "../../etc/passwd", "..", "lib/../../etc/passwd"]:
+        assert _resolve_within(str(tmp_path), path) is None, path
+
+
+def test_symlink_escape_is_rejected(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret").write_text("s")
+    root = tmp_path / "root"
+    root.mkdir()
+    os.symlink(str(outside), str(root / "link"))
+
+    assert _resolve_within(str(root), "link/secret") is None

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,0 +1,43 @@
+"""Regression tests for the SSRF guard on /api/torrent_url_to_magnet/."""
+
+import pytest
+import settings
+
+from app.app import _is_fetchable_url
+
+
+@pytest.fixture
+def indexers(monkeypatch):
+    monkeypatch.setattr(settings, "JACKETT_HOST", "http://jackett:9117")
+    monkeypatch.setattr(settings, "PROWLARR_HOST", None)
+
+
+def test_public_http_urls_are_allowed(indexers):
+    assert _is_fetchable_url("http://example.com/a.torrent")
+    assert _is_fetchable_url("https://example.com/a.torrent")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8899/probe",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.5/admin",
+        "http://192.168.1.1/",
+        "http://[::1]/",
+        "http://localhost/",
+    ],
+)
+def test_local_network_targets_are_rejected(indexers, url):
+    assert not _is_fetchable_url(url)
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "gopher://x/", "not a url", ""])
+def test_non_http_schemes_are_rejected(indexers, url):
+    assert not _is_fetchable_url(url)
+
+
+def test_configured_indexer_is_exempt(indexers):
+    # Jackett/Prowlarr normally live on a private docker network.
+    assert _is_fetchable_url("http://jackett:9117/dl/abc")
+    assert not _is_fetchable_url("http://prowlarr:9696/dl/abc")

--- a/tests/test_ssrf_guard.py
+++ b/tests/test_ssrf_guard.py
@@ -1,43 +1,112 @@
-"""Regression tests for the SSRF guard on /api/torrent_url_to_magnet/."""
+"""Regression tests for the SSRF guard on /api/torrent_url_to_magnet/.
+
+DNS is stubbed so these stay hermetic - the point is the policy and the
+connection pinning, not name resolution.
+"""
+
+import contextlib
+import http.server
+import ipaddress
+import socket
+import threading
 
 import pytest
 import settings
 
-from app.app import _is_fetchable_url
+from app.app import _fetch_target_ip, _get_pinned
+
+FAKE_DNS = {
+    "jackett": "172.18.0.5",
+    "tracker.test": "93.184.216.34",
+    "loopback.test": "127.0.0.1",
+    "metadata.test": "169.254.169.254",
+    "multicast.test": "224.0.0.1",
+    "lan.test": "192.168.1.7",
+    "v6loopback.test": "::1",
+}
 
 
-@pytest.fixture
-def indexers(monkeypatch):
+@pytest.fixture(autouse=True)
+def stub_dns_and_indexers(monkeypatch):
     monkeypatch.setattr(settings, "JACKETT_HOST", "http://jackett:9117")
     monkeypatch.setattr(settings, "PROWLARR_HOST", None)
 
+    real_getaddrinfo = socket.getaddrinfo
 
-def test_public_http_urls_are_allowed(indexers):
-    assert _is_fetchable_url("http://example.com/a.torrent")
-    assert _is_fetchable_url("https://example.com/a.torrent")
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        if host not in FAKE_DNS:
+            with contextlib.suppress(ValueError):
+                # IP literals still resolve for real, so a pinned connection
+                # can actually be made.
+                ipaddress.ip_address(host)
+                return real_getaddrinfo(host, port, *args, **kwargs)
+            raise socket.gaierror(f"stubbed NXDOMAIN for {host}")
+        ip = FAKE_DNS[host]
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+
+def test_public_host_is_allowed_and_pinned():
+    assert _fetch_target_ip("http://tracker.test/a.torrent") == "93.184.216.34"
+    assert _fetch_target_ip("https://tracker.test/a.torrent") == "93.184.216.34"
 
 
 @pytest.mark.parametrize(
     "url",
     [
-        "http://127.0.0.1:8899/probe",
-        "http://169.254.169.254/latest/meta-data/",
-        "http://10.0.0.5/admin",
-        "http://192.168.1.1/",
-        "http://[::1]/",
-        "http://localhost/",
+        "http://loopback.test/probe",
+        "http://metadata.test/latest/meta-data/",
+        "http://multicast.test/x",
+        "http://lan.test/admin",
+        "http://v6loopback.test/x",
     ],
 )
-def test_local_network_targets_are_rejected(indexers, url):
-    assert not _is_fetchable_url(url)
+def test_local_network_targets_are_rejected(url):
+    assert _fetch_target_ip(url) is None
 
 
-@pytest.mark.parametrize("url", ["file:///etc/passwd", "gopher://x/", "not a url", ""])
-def test_non_http_schemes_are_rejected(indexers, url):
-    assert not _is_fetchable_url(url)
+@pytest.mark.parametrize(
+    "url", ["file:///etc/passwd", "gopher://tracker.test/", "not a url", "", "http://nxdomain.test/x"]
+)
+def test_non_http_and_unresolvable_are_rejected(url):
+    assert _fetch_target_ip(url) is None
 
 
-def test_configured_indexer_is_exempt(indexers):
-    # Jackett/Prowlarr normally live on a private docker network.
-    assert _is_fetchable_url("http://jackett:9117/dl/abc")
-    assert not _is_fetchable_url("http://prowlarr:9696/dl/abc")
+def test_indexer_exemption_is_scoped_to_its_origin():
+    # Jackett/Prowlarr normally live on a private docker network, so the
+    # configured origin is exempt - but only that exact origin.
+    assert _fetch_target_ip("http://jackett:9117/dl/abc") == "172.18.0.5"
+    assert _fetch_target_ip("http://jackett:22/x") is None
+    assert _fetch_target_ip("https://jackett:9117/x") is None
+    assert _fetch_target_ip("http://prowlarr:9696/x") is None
+
+
+def test_connection_is_pinned_and_keeps_the_real_host_header():
+    """Closes the DNS-rebinding window: the socket goes to the validated IP,
+    not to whatever the name resolves to at connect time."""
+    seen = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            seen["host"] = self.headers.get("Host")
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        # "unresolvable.test" is absent from FAKE_DNS, so this can only
+        # connect at all because the address is pinned.
+        response = _get_pinned(f"http://unresolvable.test:{port}/dl/x", "127.0.0.1", timeout=10)
+        assert response.status_code == 200
+        assert seen["host"] == f"unresolvable.test:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()


### PR DESCRIPTION
Three reported issues, all reachable without authentication in the default deployment (PASSWORD unset).

Arbitrary file read: uvicorn percent-decodes the request path before routing and nginx's proxy_pass forwards the raw URI unnormalized, so GET /%2Fetc%2Fpasswd reached frontend() as the absolute path /etc/passwd, where os.path.join dropped the FRONTEND_DIR prefix. Add _resolve_within() and use it in frontend() and _send_from_directory().

The static branch deliberately stays unauthenticated: login.html loads /lib/jquery-3.3.1.min.js through it, so gating it would break the login page for password-protected instances. The defect was the missing containment check, not the missing auth.

play() had the same bug class - its check was anchored on OUTPUT_DIR/<magnet_hash>, so a traversing magnet_hash moved the root of the check itself. Anchor on OUTPUT_DIR.

Command injection: file names inside a torrent are attacker-controlled and were interpolated into shell strings, so a file named p$(touch${IFS}pwn).mp4 executed as root on conversion. Switch ffmpeg and alass to argument-list form. Behaviour preserved: 2>> becomes stderr=<log file> so get_conversion_progress still reads ffmpeg's stats, && mv becomes os.replace() after a zero returncode, timeout 5m becomes subprocess.run(timeout=300), and VIDEO_CONVERSION_PARAMS is shlex.split() so multi-token values keep working.

SSRF: /api/torrent_url_to_magnet/ fetched any URL. Add _is_fetchable_url()
- http(s) only, no non-global or multicast addresses - and bound the body at 10MB before it reaches the bencode/libtorrent parsers.

The configured JACKETT_HOST/PROWLARR_HOST are exempt: both example compose files put the indexers on the private docker network, and their download links are the main legitimate input, so a blanket private-IP block would break the feature.

Reported by Kery Qi <qikeyu2017@gmail.com>.