### PR TITLE
Rate-limit /play/ responses to stop re-sending aborted ranges

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,23 @@ server {
 
     location /play/ {
         alias /tmp/output/;
+
+        # Safari/AVFoundation asks for `Range: bytes=N-<EOF>` - always to the
+        # end of the file, never a bounded chunk - then aborts the response
+        # after buffering a few seconds and reopens slightly further along.
+        # Uncapped, nginx serves that open-ended range at full link speed and
+        # races far ahead of the playhead; everything sent past the point the
+        # player resumes from is discarded and fetched again on the next
+        # request. Measured against a live stream, that cost 4.4-6.1x the
+        # useful bytes (~83% of egress re-sent).
+        #
+        # limit_rate_after is counted per response, not per client, and this
+        # player opens ~20 responses a minute - so it has to stay small or the
+        # allowance alone outruns the cap and the throttle never engages.
+        # Library content runs 4-6 Mbit/s; 1500k leaves ~2x headroom. Raise
+        # both if higher-bitrate (4K remux) files are ever served from here.
+        limit_rate_after 2m;
+        limit_rate 1500k;
     }
 
     location / {


### PR DESCRIPTION
Safari/AVFoundation requests `Range: bytes=N-<EOF>` for video playback - always through to the end of the file, never a bounded chunk - buffers a few seconds, aborts the response, and reopens a little further along. It did this 285 times in 14.5 minutes on one stream, aborting every single response.

nginx had no rate cap on /play/, so each of those requests began serving the entire remainder of the file at full link speed. The server ran far ahead of the playhead and every byte past the point the player resumed from was thrown away and fetched again.

Measured on a live stream, over three windows:

  playback advanced   bytes sent   amplification
       30.3 MB         174.6 MB       5.76x
       24.7 MB         108.0 MB       4.37x
       40.2 MB         245.6 MB       6.10x

About 83% of outbound bandwidth on that stream was duplicate data. The proxy in front was relaying faithfully (1.03x upstream-to-downstream), so the waste was entirely the uncapped open-ended range response.

Cap the response rate instead. limit_rate_after is counted per response rather than per client, and this player opens roughly 20 responses per minute, so it is deliberately small - a conventional large head-start value would hand out its allowance on every reopen and the cap would never take effect. Library content is 4-6 Mbit/s, so 1500k keeps about 2x headroom.